### PR TITLE
feat: produce msgs as json

### DIFF
--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -18,6 +18,7 @@ e.g. message:
 """
 import ast
 import datetime
+import json
 from typing import Any, Dict, Optional
 
 from confluent_kafka import Consumer, Message, Producer
@@ -248,7 +249,7 @@ class DatasetProducer:
         self.producer.produce(
             topic=self.dataset,
             key=key_bytes,
-            value=str(message).encode("utf-8"),
+            value=json.dumps(message).encode("utf-8"),
             callback=self._delivery_report,
         )
         self.producer.flush()


### PR DESCRIPTION
This PR produces messages as `json` instead of `string`. This allows better compatibility with JSON based log / alert systems. @giddyphysicist mentioned that this could cause issues with serialization, but I think we should make that trade-off. For example, if a user wants to log a non-serializable object like a `ZeroDivisionError` exception, then they can just call `str()` before producing. 
<img width="1341" alt="Screenshot 2023-09-19 at 3 55 51 PM" src="https://github.com/Convex-Labs/aineko-core/assets/35337224/1b9d1426-57a6-404b-9df0-b8194d041426">
