### PR TITLE
chore: add check-license hook

### DIFF
--- a/.internals/check_license.py
+++ b/.internals/check_license.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+import sys
+from typing import List, Optional
+
+LICENSE_SNIPPET = """# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+"""
+
+
+def check_license(filename: str) -> bool:
+    """Check that the correct license snippet is present in the file.
+
+    Args:
+        filename: The file to check.
+
+    Returns:
+        True if the license snippet is present and correct, False otherwise.
+    """
+    with open(filename, "r") as f:
+        lines = [f.readline().strip() for _ in range(2)]
+        return "\n".join(lines) == LICENSE_SNIPPET.strip()
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """Main entrypoint for the check_license script."""
+    if argv is None:
+        argv = sys.argv[1:]
+
+    for filename in argv:
+        if not filename.endswith(".py"):
+            continue
+        if not check_license(filename):
+            print(f"ERROR: License snippet missing or incorrect in {filename}")
+            sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.internals/check_license.py
+++ b/.internals/check_license.py
@@ -1,5 +1,6 @@
 # Copyright 2023 Aineko Authors
 # SPDX-License-Identifier: Apache-2.0
+import argparse
 import sys
 from typing import List, Optional
 
@@ -22,19 +23,46 @@ def check_license(filename: str) -> bool:
         return "\n".join(lines) == LICENSE_SNIPPET.strip()
 
 
-def main(argv: Optional[List[str]] = None) -> None:
+def fix_license(filename: str) -> None:
+    """Add the correct license snippet to the file.
+
+    Args:
+        filename: The file to fix.
+    """
+    if not check_license(filename):
+        try:
+            print(f"Fixing license in {filename}")
+            with open(filename, "r+") as file:
+                content = file.read()
+                file.seek(0, 0)
+                file.write(LICENSE_SNIPPET + content)
+        except Exception as e:
+            print(f"ERROR: Could not fix license in {filename}: {e}")
+
+
+def main() -> None:
     """Main entrypoint for the check_license script."""
-    if argv is None:
-        argv = sys.argv[1:]
-
-    for filename in argv:
-        if not filename.endswith(".py"):
-            continue
-        if not check_license(filename):
-            print(f"ERROR: License snippet missing or incorrect in {filename}")
-            sys.exit(1)
-
-    sys.exit(0)
+    parser = argparse.ArgumentParser(
+        description="Check and fix license headers in files."
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Attempt to fix the file by adding the license snippet.",
+    )
+    parser.add_argument(
+        "filenames", nargs="+", help="The files to check or fix."
+    )
+    args = parser.parse_args()
+    for filename in args.filenames:
+        if args.fix:
+            fix_license(filename)
+        else:
+            if not check_license(filename):
+                print(
+                    f"ERROR: License snippet missing or incorrect in {filename}"
+                )
+                sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,4 +48,6 @@ repos:
         name: Check License Snippet
         entry: python .internals/check_license.py
         language: python
-        types: [python] # you can specify other file types if needed
+        files: \.(py|yml|yaml)$
+        exclude: ".pre-commit-config.yaml"
+        args: ["--fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,11 +34,18 @@ repos:
     hooks:
       - id: yamlfmt
         args: [
-          "-formatter",
-          "retain_line_breaks=true",
-          "-formatter",
-          "max_line_length=80",
-          "-formatter",
-          "scan_folded_as_literal=true", # !yamlfmt!:ignore
-        ]
+            "-formatter",
+            "retain_line_breaks=true",
+            "-formatter",
+            "max_line_length=80",
+            "-formatter",
+            "scan_folded_as_literal=true", # !yamlfmt!:ignore
+          ]
         files: \.(yml|yaml)$
+  - repo: local
+    hooks:
+      - id: check-license
+        name: Check License Snippet
+        entry: python .internals/check_license.py
+        language: python
+        types: [python] # you can specify other file types if needed


### PR DESCRIPTION
This PR adds a pre-commit hook to check if committed files have the mandatory license snippet.
If `--fix` is used, the hook will attempt to fix files when needed.
Filtering of files should be done by extension type in the .pre-commit-config.yaml