### PR TITLE
feat: update deploy schema to define load_balancers under each env

### DIFF
--- a/aineko/core/deploy_config_loader.py
+++ b/aineko/core/deploy_config_loader.py
@@ -125,4 +125,9 @@ def _generate_full_config(
                     )
                 }
             )
+
+        # Add any defined load balancers
+        full_config["environments"][env][
+            "load_balancers"
+        ] = env_pipelines.load_balancers
     return FullDeploymentConfig(**full_config)

--- a/aineko/models/deploy_config_schema.py
+++ b/aineko/models/deploy_config_schema.py
@@ -13,13 +13,14 @@ This config represents the source of truth for all deployments of aineko
 pipelines.
 """
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from pydantic import BaseModel, validator
 
 from aineko.models.deploy_config_schema_internal import (
     FullPipelines,
     GenericPipeline,
+    LoadBalancers,
     ParameterizableDefaults,
     Pipelines,
 )
@@ -31,7 +32,7 @@ class DeploymentConfig(BaseModel, extra="forbid"):
     version: str
     defaults: Optional[ParameterizableDefaults]
     pipelines: Dict[str, GenericPipeline]
-    environments: Dict[str, Pipelines]
+    environments: Dict[str, Union[Pipelines, LoadBalancers]]
 
     @validator("version")
     def semver(cls, v: str) -> str:  # pylint: disable=no-self-argument
@@ -45,7 +46,7 @@ class FullDeploymentConfig(BaseModel):
     """Full deployment configuration (Schema for deploy.yml)."""
 
     version: str
-    environments: Dict[str, FullPipelines]
+    environments: Dict[str, Union[FullPipelines, LoadBalancers]]
 
     @validator("version")
     def semver(cls, v: str) -> str:  # pylint: disable=no-self-argument

--- a/aineko/models/deploy_config_schema.py
+++ b/aineko/models/deploy_config_schema.py
@@ -13,16 +13,14 @@ This config represents the source of truth for all deployments of aineko
 pipelines.
 """
 
-from typing import Dict, Optional, Union
+from typing import Dict, Optional
 
 from pydantic import BaseModel, validator
 
 from aineko.models.deploy_config_schema_internal import (
-    FullPipelines,
+    Environment,
     GenericPipeline,
-    LoadBalancers,
     ParameterizableDefaults,
-    Pipelines,
 )
 
 
@@ -32,7 +30,7 @@ class DeploymentConfig(BaseModel, extra="forbid"):
     version: str
     defaults: Optional[ParameterizableDefaults]
     pipelines: Dict[str, GenericPipeline]
-    environments: Dict[str, Union[Pipelines, LoadBalancers]]
+    environments: Dict[str, Environment]
 
     @validator("version")
     def semver(cls, v: str) -> str:  # pylint: disable=no-self-argument
@@ -46,7 +44,7 @@ class FullDeploymentConfig(BaseModel):
     """Full deployment configuration (Schema for deploy.yml)."""
 
     version: str
-    environments: Dict[str, Union[FullPipelines, LoadBalancers]]
+    environments: Dict[str, Environment]
 
     @validator("version")
     def semver(cls, v: str) -> str:  # pylint: disable=no-self-argument

--- a/aineko/models/deploy_config_schema_internal.py
+++ b/aineko/models/deploy_config_schema_internal.py
@@ -69,19 +69,15 @@ class FullPipeline(BaseModel, extra="forbid"):
     env_vars: Optional[Dict[str, str]]
 
 
-class Pipelines(BaseModel, extra="forbid"):
-    """List of pipelines, under the top-level environments key."""
+class Environment(BaseModel, extra="forbid"):
+    """Environment defined under the top-level environments key."""
 
     pipelines: List[Union[str, Dict[str, SpecificPipeline]]]
+    load_balancers: Optional[Dict[str, List[LoadBalancer]]]
 
 
-class LoadBalancers(BaseModel, extra="forbid"):
-    """List of load balancers, under the top-level environments key."""
+class FullEnvironment(BaseModel, extra="forbid"):
+    """Environment defined under the top-level environments key."""
 
-    load_balancers: Dict[str, List[LoadBalancer]]
-
-
-class FullPipelines(BaseModel, extra="forbid"):
-    """List of complete pipelines, under the top-level environments key."""
-
-    pipelines: List[Dict[str, FullPipeline]]
+    pipelines: List[Union[Dict[str, FullPipeline], str]]
+    load_balancers: Optional[Dict[str, List[LoadBalancer]]]

--- a/aineko/models/deploy_config_schema_internal.py
+++ b/aineko/models/deploy_config_schema_internal.py
@@ -46,7 +46,7 @@ class GenericPipeline(BaseModel, extra="forbid"):
 class LoadBalancer(BaseModel, extra="forbid"):
     """Configuration for a load balancer."""
 
-    hostname: str
+    pipeline: str
     port: int
 
 
@@ -67,13 +67,18 @@ class FullPipeline(BaseModel, extra="forbid"):
     name: Optional[str]
     machine_config: MachineConfig
     env_vars: Optional[Dict[str, str]]
-    load_balancers: Optional[List[LoadBalancer]]
 
 
 class Pipelines(BaseModel, extra="forbid"):
     """List of pipelines, under the top-level environments key."""
 
     pipelines: List[Union[str, Dict[str, SpecificPipeline]]]
+
+
+class LoadBalancers(BaseModel, extra="forbid"):
+    """List of load balancers, under the top-level environments key."""
+
+    load_balancers: Dict[str, List[LoadBalancer]]
 
 
 class FullPipelines(BaseModel, extra="forbid"):

--- a/tests/conf/test_deploy.yml
+++ b/tests/conf/test_deploy.yml
@@ -16,9 +16,11 @@ environments:
       - example_pipeline:
           env_vars:
             env: develop
-          load_balancers:
-            - hostname: dev-api.aineko.dev
-              port: 8000
+
+    load_balancers:
+      dev-api.aineko.dev:
+        - pipeline: example_pipeline
+          port: 8000
 
 pipelines:
   example_pipeline:

--- a/tests/conf/test_deploy_full.yml
+++ b/tests/conf/test_deploy_full.yml
@@ -17,3 +17,8 @@ environments:
             - hostname: dev-api.aineko.dev
               port: 8000
           source: ./tests/conf/test_pipeline.yml
+
+    load_balancers:
+      dev-api.aineko.dev:
+        - pipeline: example_pipeline
+          port: 8000

--- a/tests/conf/test_deploy_full.yml
+++ b/tests/conf/test_deploy_full.yml
@@ -13,9 +13,6 @@ environments:
           env_vars:
             var_1: aineko_test
             env: develop
-          load_balancers:
-            - hostname: dev-api.aineko.dev
-              port: 8000
           source: ./tests/conf/test_pipeline.yml
 
     load_balancers:

--- a/tests/models/test_deploy_config_schema_internal.py
+++ b/tests/models/test_deploy_config_schema_internal.py
@@ -6,8 +6,8 @@ import pytest
 from pydantic import ValidationError
 
 from aineko.models.deploy_config_schema_internal import (
+    Environment,
     MachineConfig,
-    Pipelines,
     SpecificPipeline,
 )
 
@@ -38,6 +38,6 @@ def test_pipeline(pipeline_config, machine_config):
         SpecificPipeline(**pipeline_config)
 
 
-def test_pipelines(pipelines_config):
+def test_environments(pipelines_config):
     """Test Pipelines model."""
-    assert Pipelines(**pipelines_config)
+    assert Environment(**pipelines_config)


### PR DESCRIPTION
This PR updates the expected schema of a deploy config file. Notably, the load_balancers key under a specific environment allows a user to define all load balancers for a specific environment in a single place. This makes it easier to deploy a load balancer that serves multiple pipelines.

```
defaults:
  machine_config:
    type: ec2
    mem_gib: 16
    vcpu: 4
  env_vars:
    var_1: aineko_test

environments:
  develop:
    pipelines:
      - example_pipeline:
          env_vars:
            env: develop

    load_balancers:
      dev-api.aineko.dev:
        - pipeline: example_pipeline
          port: 8000

pipelines:
  example_pipeline:
    source: ./tests/conf/test_pipeline.yml
    machine_config:
      type: ec2
      mem_gib: 8
      vcpu: 2
```