### PR TITLE
refactor: continue make command on error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,15 @@ help:
 	@echo "integration-test - run integration tests suite"
 
 lint:
-	poetry run isort .
-	poetry run black .
-	poetry run pydocstyle aineko
-	poetry run pylint aineko
-	poetry run yamllint -d "{extends: relaxed, ignore-from-file: .gitignore}" .
-	poetry run mypy aineko
-	poetry run pre-commit run --all
+	@ERROR=0; \
+	poetry run isort . || ERROR=1; \
+	poetry run black . || ERROR=1; \
+	poetry run pydocstyle aineko || ERROR=1; \
+	poetry run pylint aineko || ERROR=1; \
+	poetry run yamllint -d "{extends: relaxed, ignore-from-file: .gitignore}" . || ERROR=1; \
+	poetry run mypy aineko || ERROR=1; \
+	poetry run pre-commit run --all || ERROR=1; \
+	exit $$ERROR
 
 unit-test:
 	poetry run pytest --cov aineko --ignore tests/integration tests/


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [x] Other... Dev tooling


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If a command in a makefile "block" fails, it will immediately exit. This is not helpful when running tests or linting.


## What is the new behavior?
* the test statements will set a variable ERROR to 1 if they fail, resulting in a successful statement. At the end of the block we exit with the ERROR value, resulting in exit 1 or exit 0

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
