### PR TITLE
feat: deployment_config should define pipelines as a dict instead of list

### DIFF
--- a/aineko/models/deploy_config_schema_internal.py
+++ b/aineko/models/deploy_config_schema_internal.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Internal models for deployment configuration."""
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, validator
 
@@ -71,12 +71,12 @@ class FullPipeline(BaseModel, extra="forbid"):
 
 
 class Pipelines(BaseModel, extra="forbid"):
-    """List of pipelines, under the top-level environments key."""
+    """Dict of pipelines, under the top-level environments key."""
 
-    pipelines: List[Union[str, Dict[str, SpecificPipeline]]]
+    pipelines: Dict[str, SpecificPipeline]
 
 
 class FullPipelines(BaseModel, extra="forbid"):
-    """List of complete pipelines, under the top-level environments key."""
+    """Dict of complete pipelines, under the top-level environments key."""
 
-    pipelines: List[Dict[str, FullPipeline]]
+    pipelines: Dict[str, FullPipeline]

--- a/tests/conf/test_deploy.yml
+++ b/tests/conf/test_deploy.yml
@@ -19,6 +19,7 @@ environments:
           load_balancers:
             - hostname: dev-api.aineko.dev
               port: 8000
+      - simple_example
 
 pipelines:
   example_pipeline:
@@ -27,3 +28,6 @@ pipelines:
       type: ec2
       mem_gib: 8
       vcpu: 2
+
+  simple_example:
+    source: ./tests/conf/test_pipeline.yml

--- a/tests/conf/test_deploy.yml
+++ b/tests/conf/test_deploy.yml
@@ -13,13 +13,12 @@ defaults:
 environments:
   develop:
     pipelines:
-      - example_pipeline:
-          env_vars:
-            env: develop
-          load_balancers:
-            - hostname: dev-api.aineko.dev
-              port: 8000
-      - simple_example
+      example_pipeline:
+        env_vars:
+          env: develop
+        load_balancers:
+          - hostname: dev-api.aineko.dev
+            port: 8000
 
 pipelines:
   example_pipeline:
@@ -28,6 +27,3 @@ pipelines:
       type: ec2
       mem_gib: 8
       vcpu: 2
-
-  simple_example:
-    source: ./tests/conf/test_pipeline.yml

--- a/tests/conf/test_deploy_full.yml
+++ b/tests/conf/test_deploy_full.yml
@@ -5,23 +5,15 @@ version: 0.1.1
 environments:
   develop:
     pipelines:
-      - example_pipeline:
-          machine_config:
-            type: ec2
-            mem_gib: 8
-            vcpu: 2
-          env_vars:
-            var_1: aineko_test
-            env: develop
-          load_balancers:
-            - hostname: dev-api.aineko.dev
-              port: 8000
-          source: ./tests/conf/test_pipeline.yml
-      - simple_example:
-          machine_config:
-            type: ec2
-            mem_gib: 16
-            vcpu: 4
-          env_vars:
-            var_1: aineko_test
-          source: ./tests/conf/test_pipeline.yml
+      example_pipeline:
+        machine_config:
+          type: ec2
+          mem_gib: 8
+          vcpu: 2
+        env_vars:
+          var_1: aineko_test
+          env: develop
+        load_balancers:
+          - hostname: dev-api.aineko.dev
+            port: 8000
+        source: ./tests/conf/test_pipeline.yml

--- a/tests/conf/test_deploy_full.yml
+++ b/tests/conf/test_deploy_full.yml
@@ -17,3 +17,11 @@ environments:
             - hostname: dev-api.aineko.dev
               port: 8000
           source: ./tests/conf/test_pipeline.yml
+      - simple_example:
+          machine_config:
+            type: ec2
+            mem_gib: 16
+            vcpu: 4
+          env_vars:
+            var_1: aineko_test
+          source: ./tests/conf/test_pipeline.yml

--- a/tests/conf/test_deploy_multiple.yml
+++ b/tests/conf/test_deploy_multiple.yml
@@ -1,0 +1,34 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+version: 0.1.1
+
+defaults:
+  machine_config:
+    type: ec2
+    mem_gib: 16
+    vcpu: 4
+  env_vars:
+    var_1: aineko_test
+
+environments:
+  develop:
+    pipelines:
+      example_pipeline:
+        env_vars:
+          env: develop
+        load_balancers:
+          - hostname: dev-api.aineko.dev
+            port: 8000
+      another_pipeline:
+        env_vars:
+          foo: bar
+
+pipelines:
+  example_pipeline:
+    source: ./tests/conf/test_pipeline.yml
+    machine_config:
+      type: ec2
+      mem_gib: 8
+      vcpu: 2
+  another_pipeline:
+    source: ./tests/conf/test_pipeline.yml

--- a/tests/conf/test_deploy_multiple_full.yml
+++ b/tests/conf/test_deploy_multiple_full.yml
@@ -1,0 +1,28 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+version: 0.1.1
+
+environments:
+  develop:
+    pipelines:
+      example_pipeline:
+        machine_config:
+          type: ec2
+          mem_gib: 8
+          vcpu: 2
+        env_vars:
+          var_1: aineko_test
+          env: develop
+        load_balancers:
+          - hostname: dev-api.aineko.dev
+            port: 8000
+        source: ./tests/conf/test_pipeline.yml
+      another_pipeline:
+        machine_config:
+          type: ec2
+          mem_gib: 16
+          vcpu: 4
+        env_vars:
+          var_1: aineko_test
+          foo: bar
+        source: ./tests/conf/test_pipeline.yml

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -27,3 +27,25 @@ def full_deploy_config_path():
         "conf",
         "test_deploy_full.yml",
     )
+
+
+@pytest.fixture(scope="module")
+def deploy_multiple_config_path():
+    """Deployment config yml path."""
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "conf",
+        "test_deploy_multiple.yml",
+    )
+
+
+@pytest.fixture(scope="module")
+def full_multiple_deploy_config_path():
+    """Deployment config yml path."""
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "conf",
+        "test_deploy_multiple_full.yml",
+    )

--- a/tests/core/test_deploy_config_loader.py
+++ b/tests/core/test_deploy_config_loader.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Aineko Authors
 # SPDX-License-Identifier: Apache-2.0
 """Tests for deploy_config_loader.py."""
+import pytest
 
 from aineko.core.deploy_config_loader import generate_deploy_config_from_file
 from aineko.models.deploy_config_schema import FullDeploymentConfig
@@ -19,3 +20,11 @@ def test_load_deployment_config(deploy_config_path, full_deploy_config_path):
     expected_full_config = load_yaml(full_deploy_config_path)
     expected_full_config = FullDeploymentConfig(**expected_full_config).dict()
     assert full_config == expected_full_config
+
+
+def test_load_deployment_config_invalid_type(deploy_config_path):
+    """Test deployment config loader with invalid type."""
+    with pytest.raises(ValueError):
+        generate_deploy_config_from_file(
+            deploy_config_path, config_type="invalid"
+        )

--- a/tests/core/test_deploy_config_loader.py
+++ b/tests/core/test_deploy_config_loader.py
@@ -28,3 +28,19 @@ def test_load_deployment_config_invalid_type(deploy_config_path):
         generate_deploy_config_from_file(
             deploy_config_path, config_type="invalid"
         )
+
+
+def test_load_multiple_deployment_config(
+    deploy_multiple_config_path, full_multiple_deploy_config_path
+):
+    """Test deployment config loader with multiple pipelines."""
+    user_config = generate_deploy_config_from_file(
+        deploy_multiple_config_path, config_type="user"
+    )
+
+    assert user_config
+
+    full_config = generate_deploy_config_from_file(deploy_multiple_config_path)
+    expected_full_config = load_yaml(full_multiple_deploy_config_path)
+    expected_full_config = FullDeploymentConfig(**expected_full_config).dict()
+    assert full_config == expected_full_config

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -21,13 +21,11 @@ def pipeline_config():
 @pytest.fixture(scope="function")
 def pipelines_config(pipeline_config, machine_config):
     return {
-        "pipelines": [
-            {"test_pipeline_1": pipeline_config},
-            {
-                "test_pipeline_2": {
-                    **pipeline_config,
-                    **{"machine_config": machine_config},
-                }
+        "pipelines": {
+            "test_pipeline_1": pipeline_config,
+            "test_pipeline_2": {
+                **pipeline_config,
+                **{"machine_config": machine_config},
             },
-        ]
+        },
     }


### PR DESCRIPTION
With this PR pipelines should now be defined as a dictionary of pipelines under the environment top-level key.
This has the implication that it's not possible to define pipelines a string in a deploy.yml file.