### PR TITLE
feat: add test cases for pipeline defined by name

### DIFF
--- a/tests/conf/test_deploy.yml
+++ b/tests/conf/test_deploy.yml
@@ -16,6 +16,7 @@ environments:
       - example_pipeline:
           env_vars:
             env: develop
+      - simple_example
 
     load_balancers:
       dev-api.aineko.dev:
@@ -29,3 +30,6 @@ pipelines:
       type: ec2
       mem_gib: 8
       vcpu: 2
+
+  simple_example:
+    source: ./tests/conf/test_pipeline.yml

--- a/tests/conf/test_deploy_full.yml
+++ b/tests/conf/test_deploy_full.yml
@@ -14,6 +14,14 @@ environments:
             var_1: aineko_test
             env: develop
           source: ./tests/conf/test_pipeline.yml
+      - simple_example:
+          machine_config:
+            type: ec2
+            mem_gib: 16
+            vcpu: 4
+          env_vars:
+            var_1: aineko_test
+          source: ./tests/conf/test_pipeline.yml
 
     load_balancers:
       dev-api.aineko.dev:

--- a/tests/core/test_deploy_config_loader.py
+++ b/tests/core/test_deploy_config_loader.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Aineko Authors
 # SPDX-License-Identifier: Apache-2.0
 """Tests for deploy_config_loader.py."""
+import pytest
 
 from aineko.core.deploy_config_loader import generate_deploy_config_from_file
 from aineko.models.deploy_config_schema import FullDeploymentConfig
@@ -19,3 +20,11 @@ def test_load_deployment_config(deploy_config_path, full_deploy_config_path):
     expected_full_config = load_yaml(full_deploy_config_path)
     expected_full_config = FullDeploymentConfig(**expected_full_config).dict()
     assert full_config == expected_full_config
+
+
+def test_load_deployment_config_invalid_type(deploy_config_path):
+    """Test deployment config loader with invalid type."""
+    with pytest.raises(ValueError):
+        generate_deploy_config_from_file(
+            deploy_config_path, config_type="invalid"
+        )


### PR DESCRIPTION
This PR adds a test for cases where a user calls the `generate_deploy_config_from_file` with an invalid `config_type`.
It also adds a second pipeline to test_deploy.yml which is only defined by it's name.