### PR TITLE
fix: print_help if only the prog is called

### DIFF
--- a/aineko/__main__.py
+++ b/aineko/__main__.py
@@ -144,7 +144,10 @@ def _cli() -> None:
     )
 
     args = parser.parse_args()
-    args.func(args)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Without this check running `aineko` in the terminal would fail instead of printing the help message.