### PR TITLE
feat: added prefixing capabilities

### DIFF
--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -89,7 +89,7 @@ class DatasetConsumer:
                 "group.id"
             ] = f"{prefix}.{pipeline_name}.{node_name}"
             self.consumer = Consumer(consumer_config)
-            self.consumer.subscribe([f"{prefix}.topic_name"])
+            self.consumer.subscribe([f"{prefix}.{topic_name}"])
 
         else:
             consumer_config["group.id"] = f"{pipeline_name}.{node_name}"

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -96,6 +96,8 @@ class DatasetConsumer:
             self.consumer = Consumer(consumer_config)
             self.consumer.subscribe([topic_name])
 
+        self.topic_name = topic_name
+
     @staticmethod
     def _validate_message(
         message: Optional[Message] = None,

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -33,10 +33,15 @@ class DatasetConsumer:
 
     DatasetConsumer objects are designed to consume messages from a single
     dataset and will consume the next unconsumed message in the queue.
-    Prefixes will automatically be added to the dataset name. For example,
-    a dataset named "dataset_1" in a pipeline named "pipeline_1" with a prefix
-    of "test" will subscribe to a topic named "test.pipeline_1.dataset_1" if
-    `has_pipeline_prefix` is set to `True`, and "test.dataset_1" otherwise.
+
+    When accessing kafka topics, prefixes will automatically be added to the
+    dataset name as part of namespacing. For datasets defined in the pipeline
+    config, `has_pipeline_prefix` will be set to `True`, so a dataset named
+    `my_dataset` will point to a topic named `my_pipeline.my_dataset`.
+
+    Optionally, a custom prefix can be provided that will apply to all datasets.
+    In the above example, if the prefix is set to `test`, the topic name will
+    be `test.my_pipeline.my_dataset`.
 
     Args:
         dataset_name: name of the dataset

--- a/aineko/core/node.py
+++ b/aineko/core/node.py
@@ -113,7 +113,7 @@ class AbstractNode(ABC):
             pipeline: name of the pipeline
             inputs: list of dataset names for the inputs to the node
             outputs: list of dataset names for the outputs of the node
-            prefix: prefix for topic name (<prefix>.<dataset_name>)
+            prefix: prefix for topic name (`<prefix>.<dataset_name>`)
             has_pipeline_prefix: whether the dataset name has pipeline name
             prefix
         """

--- a/aineko/core/node.py
+++ b/aineko/core/node.py
@@ -102,6 +102,8 @@ class AbstractNode(ABC):
         pipeline: str,
         inputs: Optional[List[str]] = None,
         outputs: Optional[List[str]] = None,
+        prefix: Optional[str] = None,
+        has_pipeline_prefix: bool = False,
     ) -> None:
         """Setup the consumer and producer for a node.
 
@@ -111,28 +113,39 @@ class AbstractNode(ABC):
             pipeline: name of the pipeline
             inputs: list of dataset names for the inputs to the node
             outputs: list of dataset names for the outputs of the node
+            prefix: prefix for topic name (<prefix>.<dataset_name>)
+            has_pipeline_prefix: whether the dataset name has pipeline name
+            prefix
         """
         inputs = inputs or []
-        self.consumers = {
-            dataset_name: DatasetConsumer(
-                dataset_name=dataset_name,
-                node_name=node,
-                dataset_config=datasets.get(dataset_name, {}),
-                pipeline_name=pipeline,
-            )
-            for dataset_name in inputs
-        }
+        self.consumers.update(
+            {
+                dataset_name: DatasetConsumer(
+                    dataset_name=dataset_name,
+                    node_name=node,
+                    pipeline_name=pipeline,
+                    dataset_config=datasets.get(dataset_name, {}),
+                    prefix=prefix,
+                    has_pipeline_prefix=has_pipeline_prefix,
+                )
+                for dataset_name in inputs
+            }
+        )
 
         outputs = outputs or []
-        self.producers = {
-            dataset_name: DatasetProducer(
-                dataset_name=dataset_name,
-                node_name=node,
-                dataset_config=datasets.get(dataset_name, {}),
-                pipeline_name=pipeline,
-            )
-            for dataset_name in outputs
-        }
+        self.producers.update(
+            {
+                dataset_name: DatasetProducer(
+                    dataset_name=dataset_name,
+                    node_name=node,
+                    pipeline_name=pipeline,
+                    dataset_config=datasets.get(dataset_name, {}),
+                    prefix=prefix,
+                    has_pipeline_prefix=has_pipeline_prefix,
+                )
+                for dataset_name in outputs
+            }
+        )
 
     def setup_test(
         self,

--- a/poetry.lock
+++ b/poetry.lock
@@ -284,33 +284,29 @@ chardet = ">=3.0.2"
 
 [[package]]
 name = "black"
-version = "23.9.1"
+version = "23.10.0"
 description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "black-23.9.1-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:d6bc09188020c9ac2555a498949401ab35bb6bf76d4e0f8ee251694664df6301"},
-    {file = "black-23.9.1-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:13ef033794029b85dfea8032c9d3b92b42b526f1ff4bf13b2182ce4e917f5100"},
-    {file = "black-23.9.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:75a2dc41b183d4872d3a500d2b9c9016e67ed95738a3624f4751a0cb4818fe71"},
-    {file = "black-23.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13a2e4a93bb8ca74a749b6974925c27219bb3df4d42fc45e948a5d9feb5122b7"},
-    {file = "black-23.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:adc3e4442eef57f99b5590b245a328aad19c99552e0bdc7f0b04db6656debd80"},
-    {file = "black-23.9.1-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:8431445bf62d2a914b541da7ab3e2b4f3bc052d2ccbf157ebad18ea126efb91f"},
-    {file = "black-23.9.1-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:8fc1ddcf83f996247505db6b715294eba56ea9372e107fd54963c7553f2b6dfe"},
-    {file = "black-23.9.1-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:7d30ec46de88091e4316b17ae58bbbfc12b2de05e069030f6b747dfc649ad186"},
-    {file = "black-23.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031e8c69f3d3b09e1aa471a926a1eeb0b9071f80b17689a655f7885ac9325a6f"},
-    {file = "black-23.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:538efb451cd50f43aba394e9ec7ad55a37598faae3348d723b59ea8e91616300"},
-    {file = "black-23.9.1-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:638619a559280de0c2aa4d76f504891c9860bb8fa214267358f0a20f27c12948"},
-    {file = "black-23.9.1-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:a732b82747235e0542c03bf352c126052c0fbc458d8a239a94701175b17d4855"},
-    {file = "black-23.9.1-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:cf3a4d00e4cdb6734b64bf23cd4341421e8953615cba6b3670453737a72ec204"},
-    {file = "black-23.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf99f3de8b3273a8317681d8194ea222f10e0133a24a7548c73ce44ea1679377"},
-    {file = "black-23.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:14f04c990259576acd093871e7e9b14918eb28f1866f91968ff5524293f9c573"},
-    {file = "black-23.9.1-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:c619f063c2d68f19b2d7270f4cf3192cb81c9ec5bc5ba02df91471d0b88c4c5c"},
-    {file = "black-23.9.1-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:6a3b50e4b93f43b34a9d3ef00d9b6728b4a722c997c99ab09102fd5efdb88325"},
-    {file = "black-23.9.1-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:c46767e8df1b7beefb0899c4a95fb43058fa8500b6db144f4ff3ca38eb2f6393"},
-    {file = "black-23.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50254ebfa56aa46a9fdd5d651f9637485068a1adf42270148cd101cdf56e0ad9"},
-    {file = "black-23.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:403397c033adbc45c2bd41747da1f7fc7eaa44efbee256b53842470d4ac5a70f"},
-    {file = "black-23.9.1-py3-none-any.whl", hash = "sha256:6ccd59584cc834b6d127628713e4b6b968e5f79572da66284532525a042549f9"},
-    {file = "black-23.9.1.tar.gz", hash = "sha256:24b6b3ff5c6d9ea08a8888f6977eae858e1f340d7260cf56d70a49823236b62d"},
+    {file = "black-23.10.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:f8dc7d50d94063cdfd13c82368afd8588bac4ce360e4224ac399e769d6704e98"},
+    {file = "black-23.10.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:f20ff03f3fdd2fd4460b4f631663813e57dc277e37fb216463f3b907aa5a9bdd"},
+    {file = "black-23.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3d9129ce05b0829730323bdcb00f928a448a124af5acf90aa94d9aba6969604"},
+    {file = "black-23.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:960c21555be135c4b37b7018d63d6248bdae8514e5c55b71e994ad37407f45b8"},
+    {file = "black-23.10.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:30b78ac9b54cf87bcb9910ee3d499d2bc893afd52495066c49d9ee6b21eee06e"},
+    {file = "black-23.10.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:0e232f24a337fed7a82c1185ae46c56c4a6167fb0fe37411b43e876892c76699"},
+    {file = "black-23.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31946ec6f9c54ed7ba431c38bc81d758970dd734b96b8e8c2b17a367d7908171"},
+    {file = "black-23.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:c870bee76ad5f7a5ea7bd01dc646028d05568d33b0b09b7ecfc8ec0da3f3f39c"},
+    {file = "black-23.10.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:6901631b937acbee93c75537e74f69463adaf34379a04eef32425b88aca88a23"},
+    {file = "black-23.10.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:481167c60cd3e6b1cb8ef2aac0f76165843a374346aeeaa9d86765fe0dd0318b"},
+    {file = "black-23.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f74892b4b836e5162aa0452393112a574dac85e13902c57dfbaaf388e4eda37c"},
+    {file = "black-23.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:47c4510f70ec2e8f9135ba490811c071419c115e46f143e4dce2ac45afdcf4c9"},
+    {file = "black-23.10.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:76baba9281e5e5b230c9b7f83a96daf67a95e919c2dfc240d9e6295eab7b9204"},
+    {file = "black-23.10.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:a3c2ddb35f71976a4cfeca558848c2f2f89abc86b06e8dd89b5a65c1e6c0f22a"},
+    {file = "black-23.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db451a3363b1e765c172c3fd86213a4ce63fb8524c938ebd82919bf2a6e28c6a"},
+    {file = "black-23.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:7fb5fc36bb65160df21498d5a3dd330af8b6401be3f25af60c6ebfe23753f747"},
+    {file = "black-23.10.0-py3-none-any.whl", hash = "sha256:e223b731a0e025f8ef427dd79d8cd69c167da807f5710add30cdf131f13dd62e"},
+    {file = "black-23.10.0.tar.gz", hash = "sha256:31b9f87b277a68d0e99d2905edae08807c007973eaa609da5f0c62def6b7c0bd"},
 ]
 
 [package.dependencies]
@@ -3168,13 +3164,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.6"
+version = "2.0.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.6-py3-none-any.whl", hash = "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2"},
-    {file = "urllib3-2.0.6.tar.gz", hash = "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"},
+    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
+    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
 ]
 
 [package.extras]

--- a/tests/conf/integration_test_read.yml
+++ b/tests/conf/integration_test_read.yml
@@ -7,7 +7,11 @@ pipeline:
     num_cpus: 0.5
 
   nodes:
-    sequence:
+    write:
+      class: tests.integration.test_runner_with_kafka.MessageWriter
+      outputs:
+        - messages
+    read:
       class: tests.integration.test_runner_with_kafka.MessageReader
       inputs:
         - messages

--- a/tests/integration/test_runner_with_kafka.py
+++ b/tests/integration/test_runner_with_kafka.py
@@ -58,6 +58,8 @@ class MessageReader(AbstractNode):
         """Read message"""
         msg = self.consumers["messages"].consume()
         if time.time() - self.last_updated > self.timeout:
+            print(f"Received messages: {self.received}")
+            print(self.consumers["messages"].topic_name)
             raise TimeoutError("Timed out waiting for messages.")
 
         if not msg:

--- a/tests/integration/test_runner_with_kafka.py
+++ b/tests/integration/test_runner_with_kafka.py
@@ -105,6 +105,7 @@ def test_write_read_to_kafka():
             node_name="consumer",
             pipeline_name="integration_test_write",
             dataset_config={},
+            has_pipeline_prefix=True,
         )
         count_messages = consumer.consume_all(end_message="END")
         count_values = [msg["message"] for msg in count_messages]
@@ -121,6 +122,7 @@ def test_write_read_to_kafka():
             node_name="consumer",
             pipeline_name="integration_test_read",
             dataset_config={},
+            has_pipeline_prefix=True,
         )
         count_messages = consumer.consume_all(end_message="END")
         assert count_messages[0]["source_pipeline"] == "integration_test_read"


### PR DESCRIPTION
This PR adds the ability to namespace kafka topics created by the datasets.
Datasets defined will have a prefix containing the pipeline name added, and an optional universal prefix that can be defined by the user. Topic names will be:
```
<universal_prefix>.<pipeline_name>.<dataset_name>
```