### PR TITLE
feat: implement method for testing the node state, input & output at each iteration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,7 @@ def test_doubler_node():
                 params: Defaults to None.
             """
             self.cur_time = time.time()
+            self.cur_integer = 0
 
         def _execute(self, params: Optional[dict] = None) -> None:
             """Generates a sequence of integers and writes them to a dataset.
@@ -158,6 +159,7 @@ def test_doubler_node():
 
             # Convert message to integer
             cur_integer = int(cur_integer["message"])
+            self.cur_integer = cur_integer
 
             # Write message to producer
             self.producers["integer_doubles"].produce(cur_integer * 2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,3 +166,33 @@ def test_doubler_node():
             self.log(f"Produced {cur_integer * 2}", level="info")
 
     return TestDoubler
+
+
+@pytest.fixture(scope="module")
+def test_internal_value_setter_node():
+    """Returns a node that sets the current input as an internal value."""
+
+    class TestInternalValueSetter(AbstractNode):
+        """Test sequencer node."""
+
+        def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+            """Pre loop hook."""
+            self.cur_integer = 0
+            self.num_messages = 0
+
+        def _execute(self, params: Optional[dict] = None) -> None:
+            """Consumes message from input and sets content to internal value."""
+
+            # Read message from consumer
+            cur_integer = self.consumers["integer_sequence"].consume(
+                how="next", timeout=0
+            )
+            # Validate message
+            if cur_integer is None:
+                return
+
+            # Convert message to integer
+            cur_integer = int(cur_integer["message"])
+            self.cur_integer = cur_integer
+
+    return TestInternalValueSetter

--- a/tests/core/test_node.py
+++ b/tests/core/test_node.py
@@ -69,3 +69,16 @@ def test_output_yielding(test_sequencer_node, test_doubler_node) -> None:
     )
     for _, output, node_instance in doubler.run_test_yield():
         assert output["integer_doubles"] == node_instance.cur_integer * 2
+
+
+def test_output_yielding_no_output(test_internal_value_setter_node):
+    """Test internal value setter node, focusing on the node state per iteration."""
+    node: AbstractNode = test_internal_value_setter_node(
+        test=True, poison_pill=None
+    )
+
+    input_sequence = list(range(NUM_MESSAGES))
+    node.setup_test(inputs={"integer_sequence": input_sequence}, outputs=[])
+    for input, _, node_instance in node.run_test_yield():
+        if input.get("integer_sequence"):
+            assert input["integer_sequence"] == node_instance.cur_integer + 1


### PR DESCRIPTION
This PR implements a new method for unit testing nodes. The main difference with the current `run_test` method is that this method yields the input, output and node instance at each iteration of the loop.  This allows us to:
* test intermediate outputs instead of the aggregated output at the end of the loop
* access the internal state of the node at each iteration
* access the node methods at each iteration