### PR TITLE
refactor: replace Schema with Pydantic model

### DIFF
--- a/aineko/models/config_schema.py
+++ b/aineko/models/config_schema.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Internal models for pipeline config validation."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class Config(BaseModel):
+    """Config model."""
+
+    class Pipeline(BaseModel):
+        """Pipeline model."""
+
+        class Dataset(BaseModel):
+            """Dataset model."""
+
+            type: str
+            params: Optional[dict]
+
+        class Node(BaseModel):
+            """Node model."""
+
+            class_name: str = Field(..., alias="class")
+            node_params: Optional[dict]
+            node_settings: Optional[dict]
+            inputs: Optional[list]
+            outputs: Optional[list]
+
+        name: str
+        default_node_settings: Optional[dict]
+        nodes: dict[str, Node]
+        datasets: dict[str, Dataset]
+
+    pipeline: Pipeline

--- a/poetry.lock
+++ b/poetry.lock
@@ -665,17 +665,6 @@ protobuf = ["protobuf", "requests"]
 schema-registry = ["requests"]
 
 [[package]]
-name = "contextlib2"
-version = "21.6.0"
-description = "Backports and enhancements for the contextlib module"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "contextlib2-21.6.0-py2.py3-none-any.whl", hash = "sha256:3fbdb64466afd23abaf6c977627b75b6139a5a3e8ce38405c5b413aed7a0471f"},
-    {file = "contextlib2-21.6.0.tar.gz", hash = "sha256:ab1e2bfe1d01d968e1b7e8d9023bc51ef3509bba217bb730cee3827e1ee82869"},
-]
-
-[[package]]
 name = "cookiecutter"
 version = "2.4.0"
 description = "A command-line utility that creates projects from project templates, e.g. creating a Python package project from a Python package project template."
@@ -1375,6 +1364,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -2738,20 +2737,6 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
-name = "schema"
-version = "0.7.5"
-description = "Simple data validation library"
-optional = false
-python-versions = "*"
-files = [
-    {file = "schema-0.7.5-py2.py3-none-any.whl", hash = "sha256:f3ffdeeada09ec34bf40d7d79996d9f7175db93b7a5065de0faa7f41083c1e6c"},
-    {file = "schema-0.7.5.tar.gz", hash = "sha256:f06717112c61895cabc4707752b88716e8420a8819d71404501e114f91043197"},
-]
-
-[package.dependencies]
-contextlib2 = ">=0.5.5"
-
-[[package]]
 name = "setuptools"
 version = "68.2.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -3413,4 +3398,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.11"
-content-hash = "22d713bbe4e9da8001838a27ecc52939a55277c66d1e83b0b3c3903d4e1bc78e"
+content-hash = "11efe57ec3fece99cb39531d29957a02546d949e1059dcd206f1fc0b3ee89645"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ python = ">=3.10,<3.11"
 pydantic = "<2"
 PyYAML = "^6.0.1"
 types-PyYAML = "^6.0.1"
-schema = "^0.7.5"
 confluent-kafka = "^2.2.0"
 ray = { extras = ["default"], version = "^2.6.3" }
 cookiecutter = "^2.4.0"

--- a/tests/conf/test_invalid_pipeline.yml
+++ b/tests/conf/test_invalid_pipeline.yml
@@ -1,0 +1,40 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+pipeline:
+  name: test_invalid_pipeline
+
+  default_node_settings:
+    num_cpus: 0.5
+
+  nodes:
+    # Test actor with no input, single output, and params
+    sequencer:
+      class: aineko.tests.conftest.TestSequencer
+      outputs:
+        - integer_sequence
+        - env_var
+      node_params:
+        start_int: 0
+        num_messages: 25
+        sleep_time: 1
+
+    # Test actor with single input and single output
+    doubler:
+      inputs:
+        - integer_sequence
+      outputs:
+        - integer_doubles
+      node_params:
+        duration: 40
+
+  datasets:
+    integer_sequence:
+      type: kafka_stream
+      params:
+        retention.ms: 86400000
+
+    integer_doubles:
+      type: kafka_stream
+
+    env_var:
+      type: kafka_stream

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,16 @@ def test_pipeline_config_file(conf_directory: str):
 
 
 @pytest.fixture(scope="module")
+def test_invalid_pipeline_config_file(conf_directory: str):
+    """Pipeline config file fixture.
+
+    Returns:
+        str: Path to pipeline config file
+    """
+    return os.path.join(conf_directory, "test_invalid_pipeline.yml")
+
+
+@pytest.fixture(scope="module")
 def config_loader(test_pipeline_config_file: str):
     """Config loader fixture.
 


### PR DESCRIPTION
This PR replaces the Schema definition in config_loader with a Pydantic model.
The docstrings were stale and have also been updated to reflect the fact that we only load one pipeline config and we don't use projects anymore.