### PR TITLE
chore: activate pydantic mypy plugin + rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -520,6 +520,13 @@ disallow_untyped_defs = true
 warn_unreachable = true
 
 exclude = ["build", "tests", "venv", "^aineko/templates/"]
+plugins = ["pydantic.mypy"]
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
+warn_untyped_fields = true
 
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
This PR activates the Pydanitc mypy plugin to improve it's ability to type check Pydantic models.
More context can be found in the [docs](https://docs.pydantic.dev/1.10/mypy_plugin/).