### PR TITLE
feat: define pipeline name in runner

### DIFF
--- a/aineko/__main__.py
+++ b/aineko/__main__.py
@@ -45,9 +45,12 @@ def _run_parser(subparser: argparse._SubParsersAction) -> None:
         help="Path to the config file containing the pipeline config.",
         type=str,
     )
+    run_parser.add_argument(
+        "-p", "--pipeline", help="Name of the pipeline to run (optional)."
+    )
     run_parser.set_defaults(
         func=lambda args: run_main(
-            pipeline_config_file=args.config_path,
+            pipeline_config_file=args.config_path, pipeline_name=args.pipeline
         )
     )
 

--- a/aineko/cli/run.py
+++ b/aineko/cli/run.py
@@ -1,16 +1,22 @@
 # Copyright 2023 Aineko Authors
 # SPDX-License-Identifier: Apache-2.0
 """Module to run a pipeline from the command line."""
+from typing import Optional
+
 from aineko.core.runner import Runner
 
 
 def main(
     pipeline_config_file: str,
+    pipeline_name: Optional[str] = None,
 ) -> None:
     """Main function to run a pipeline from the command line.
 
     Args:
         pipeline_config_file: Path to the file containing the pipeline config
+        pipeline_name: Name of the pipeline to run, overrides the name defined in pipeline config
     """
-    runner = Runner(pipeline_config_file=pipeline_config_file)
+    runner = Runner(
+        pipeline_config_file=pipeline_config_file, pipeline_name=pipeline_name
+    )
     runner.run()

--- a/aineko/cli/run.py
+++ b/aineko/cli/run.py
@@ -14,7 +14,7 @@ def main(
 
     Args:
         pipeline_config_file: Path to the file containing the pipeline config
-        pipeline_name: Name of the pipeline to run, overrides the name defined in pipeline config
+        pipeline_name: Name of the pipeline to run, overrides pipeline config
     """
     runner = Runner(
         pipeline_config_file=pipeline_config_file, pipeline_name=pipeline_name

--- a/aineko/core/runner.py
+++ b/aineko/core/runner.py
@@ -22,13 +22,14 @@ class Runner:
 
     Args:
         pipeline_config_file (str): Path to pipeline config file
-        pipeline (str): Name of the pipeline
+        pipeline_name (str): Name of the pipeline
         kafka_config (dict): Config for kafka broker
         dataset_prefix (Optional[str]): Prefix for dataset names.
         Kafka topics will be called <prefix>.<pipeline>.<dataset_name>.
 
     Attributes:
         pipeline_config_file (str): Path to pipeline config file
+        pipeline_name (str): Name of the pipeline, overrides pipeline config
         kafka_config (dict): Config for kafka broker
         pipeline_name (str): Name of the pipeline, loaded from config
         dataset_prefix (Optional[str]): Prefix for dataset names
@@ -37,6 +38,7 @@ class Runner:
     def __init__(
         self,
         pipeline_config_file: str,
+        pipeline_name: Optional[str] = None,
         kafka_config: dict = DEFAULT_KAFKA_CONFIG.get("BROKER_CONFIG"),
         metrics_export_port: int = AINEKO_CONFIG.get("RAY_METRICS_PORT"),
         dataset_prefix: Optional[str] = None,
@@ -45,7 +47,7 @@ class Runner:
         self.pipeline_config_file = pipeline_config_file
         self.kafka_config = kafka_config
         self.metrics_export_port = metrics_export_port
-        self.pipeline_name: str
+        self.pipeline_name = pipeline_name
         self.dataset_prefix = dataset_prefix or ""
 
     def run(self) -> None:
@@ -61,12 +63,7 @@ class Runner:
         """
         # Load pipeline config
         pipeline_config = self.load_pipeline_config()
-        try:
-            self.pipeline_name = pipeline_config["name"]
-        except KeyError as e:
-            print(
-                f"[Warning] Failed to load pipeline name from config. {str(e)}"
-            )
+        self.pipeline_name = self.pipeline_name or pipeline_config["name"]
 
         # Create the necessary datasets
         self.prepare_datasets(


### PR DESCRIPTION
Pipeline name can be defined in the CLI command to invoke the runner, which overrides the pipeline name defined in the pipeline config. This allows the deployment of multiple pipelines from the same configuration with different namespaces.