### PR TITLE
fix: include nodes without inputs or outputs in graph

### DIFF
--- a/aineko/cli/visualize.py
+++ b/aineko/cli/visualize.py
@@ -61,28 +61,37 @@ def build_mermaid_from_yaml(
                 transitions.append(
                     {"node": node_name, "output": output_dataset}
                 )
+        if (
+            "inputs" not in node_subscriptions.keys()
+            and "outputs" not in node_subscriptions.keys()
+        ):
+            transitions.append({"node": node_name})
 
     mermaid_transitions = []
 
     for transition in transitions:
-        if "input" in transition.keys():
-            src_node = (
-                f"T_{transition['input']}[{transition['input']}]"
-                ":::datasetClass"
-            )
-            tgt_node = (
+        if (
+            not "input" in transition.keys()
+            and not "output" in transition.keys()
+        ):
+            mermaid_transitions.append(
                 f"N_{transition['node']}(({transition['node']})):::nodeClass"
             )
-        elif "output" in transition.keys():
-            src_node = (
-                f"N_{transition['node']}(({transition['node']})):::nodeClass"
-            )
-            tgt_node = (
-                f"T_{transition['output']}[{transition['output']}]"
-                ":::datasetClass"
-            )
+        else:
+            if "input" in transition.keys():
+                src_node = (
+                    f"T_{transition['input']}[{transition['input']}]"
+                    ":::datasetClass"
+                )
+                tgt_node = f"N_{transition['node']}(({transition['node']})):::nodeClass"  # pylint: disable=line-too-long
+            elif "output" in transition.keys():
+                src_node = f"N_{transition['node']}(({transition['node']})):::nodeClass"  # pylint: disable=line-too-long
+                tgt_node = (
+                    f"T_{transition['output']}[{transition['output']}]"
+                    ":::datasetClass"
+                )
 
-        mermaid_transitions.append(f"{src_node} -->  {tgt_node}")
+            mermaid_transitions.append(f"{src_node} -->  {tgt_node}")
 
     header = f"flowchart {direction}\nclassDef datasetClass "
     header += "fill:#87CEEB\nclassDef nodeClass fill:#eba487"

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -35,6 +35,7 @@ N_sequencer((sequencer)):::nodeClass -->  T_integer_sequence[integer_sequence]::
 N_sequencer((sequencer)):::nodeClass -->  T_env_var[env_var]:::datasetClass
 T_integer_sequence[integer_sequence]:::datasetClass -->  N_doubler((doubler)):::nodeClass
 N_doubler((doubler)):::nodeClass -->  T_integer_doubles[integer_doubles]:::datasetClass
+N_dummy((dummy)):::nodeClass
 """,
         "legend": """subgraph Legend
 node((Node)):::nodeClass

--- a/tests/conf/test_pipeline.yml
+++ b/tests/conf/test_pipeline.yml
@@ -27,6 +27,9 @@ pipeline:
         - integer_doubles
       node_params:
         duration: 40
+    # Test actor with no input, no output, and no params
+    dummy:
+      class: aineko.tests.conftest.DummyNode
 
   datasets:
     integer_sequence:

--- a/tests/core/test_config_loader.py
+++ b/tests/core/test_config_loader.py
@@ -29,6 +29,7 @@ EXPECTED_TEST_PIPELINE = {
                 "outputs": ["integer_doubles"],
                 "node_params": {"duration": 40},
             },
+            "dummy": {"class": "aineko.tests.conftest.DummyNode"},
         },
         "datasets": {
             "integer_sequence": {


### PR DESCRIPTION
In the previous version, only nodes with input or outputs were included in the graph. This is now resolved and all nodes will be displayed.