### PR TITLE
feat: add logger for Aineko

### DIFF
--- a/aineko/__main__.py
+++ b/aineko/__main__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Aineko command line interface."""
 import argparse
+import logging
 
 from aineko import __version__
 from aineko.cli.create_pipeline import create_pipeline_directory
@@ -9,6 +10,15 @@ from aineko.cli.docker_cli_wrapper import DockerCLIWrapper
 from aineko.cli.kafka_cli_wrapper import KafkaCLIWrapper
 from aineko.cli.run import main as run_main
 from aineko.cli.visualize import render_mermaid_graph
+
+
+def _setup_logging() -> None:
+    """Setup logging for the application."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s.%(msecs)d - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
 
 def _create_parser(subparser: argparse._SubParsersAction) -> None:
@@ -209,4 +219,7 @@ def _cli() -> None:
 
 
 if __name__ == "__main__":
+    _setup_logging()
+    logger = logging.getLogger("aineko")
+    logger.info("Application is starting.")
     _cli()

--- a/aineko/cli/run.py
+++ b/aineko/cli/run.py
@@ -1,11 +1,14 @@
 # Copyright 2023 Aineko Authors
 # SPDX-License-Identifier: Apache-2.0
 """Module to run a pipeline from the command line."""
+import logging
 import time
 import traceback
 from typing import Optional
 
 from aineko.core.runner import Runner
+
+logger = logging.getLogger(__name__)
 
 
 def main(
@@ -31,7 +34,7 @@ def main(
             if not retry:
                 raise e
             else:
-                print(f"Error running pipeline: {e}")
-                print(traceback.format_exc())
+                logger.error("Error running pipeline: %s", e)
+                logger.debug(traceback.format_exc())
                 time.sleep(10)
                 continue

--- a/aineko/core/config_loader.py
+++ b/aineko/core/config_loader.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Aineko Authors
 # SPDX-License-Identifier: Apache-2.0
 """Module to load config files."""
+import logging
 from typing import Union, overload
 
 from pydantic import ValidationError
@@ -8,6 +9,8 @@ from pydantic import ValidationError
 from aineko.config import AINEKO_CONFIG
 from aineko.models.config_schema import Config
 from aineko.utils.io import load_yaml
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigLoader:
@@ -51,10 +54,11 @@ class ConfigLoader:
         try:
             Config(**config)
         except ValidationError as e:
-            print(
-                f"Schema validation failed for pipeline "
-                f"`{config['pipeline']['name']}` loaded from "
-                f"{self.pipeline_config_file}. See detailed error below."
+            logger.error(
+                "Schema validation failed for pipeline `%s` loaded from %s. "
+                "See detailed error below.",
+                config["pipeline"]["name"],
+                self.pipeline_config_file,
             )
             raise e
 

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -20,11 +20,14 @@ e.g. message:
 """
 import datetime
 import json
+import logging
 from typing import Any, Dict, Optional
 
 from confluent_kafka import Consumer, Message, Producer  # type: ignore
 
 from aineko.config import AINEKO_CONFIG, DEFAULT_KAFKA_CONFIG
+
+logger = logging.getLogger(__name__)
 
 
 # pylint: disable=too-few-public-methods
@@ -120,7 +123,7 @@ class DatasetConsumer:
 
         # Check if message is an error
         if message.error():
-            print(message.error())
+            logger.error(str(message.error()))
             return None
 
         # Convert message to dict
@@ -244,7 +247,7 @@ class DatasetProducer:
             message: message object from Kafka
         """
         if err is not None:
-            print(f"Message {message} delivery failed: {err}")
+            logger.error("Message %s delivery failed: %s", message, err)
 
     def produce(self, message: dict, key: Optional[str] = None) -> None:
         """Produce a message to the dataset.

--- a/aineko/core/runner.py
+++ b/aineko/core/runner.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Aineko Authors
 # SPDX-License-Identifier: Apache-2.0
 """Submodule that handles the running of a pipeline from config."""
+import logging
 import time
 from typing import Optional
 
@@ -15,6 +16,8 @@ from aineko.config import (
 from aineko.core.config_loader import ConfigLoader
 from aineko.core.node import PoisonPill
 from aineko.utils import imports
+
+logger = logging.getLogger(__name__)
 
 
 class Runner:
@@ -158,7 +161,9 @@ class Runner:
         # Create all dataset defined in the catalog
         dataset_list = []
         for dataset_name, dataset_config in config.items():
-            print(f"Creating dataset: {dataset_name}: {dataset_config}")
+            logger.info(
+                "Creating dataset: %s: %s", dataset_name, dataset_config
+            )
             # Create dataset for kafka streams
             if dataset_config["type"] == AINEKO_CONFIG.get("KAFKA_STREAM_TYPE"):
                 # User defined
@@ -196,7 +201,7 @@ class Runner:
         cur_time = time.time()
         while True:
             if all(future.done() for future in datasets.values()):
-                print("All datasets created.")
+                logger.info("All datasets created.")
                 break
             if time.time() - cur_time > AINEKO_CONFIG.get(
                 "DATASET_CREATION_TIMEOUT"

--- a/tests/core/test_config_loader.py
+++ b/tests/core/test_config_loader.py
@@ -59,7 +59,7 @@ def test_load_config(
     assert config == EXPECTED_TEST_PIPELINE
 
 
-def test_load_invalid_config(test_invalid_pipeline_config_file: str, capsys):
+def test_load_invalid_config(test_invalid_pipeline_config_file: str, caplog):
     """Tests the loading of an invalid config.
 
     The class name is missing from the doubler node definition.
@@ -74,13 +74,12 @@ def test_load_invalid_config(test_invalid_pipeline_config_file: str, capsys):
             "type": "value_error.missing",
         }
     ]
-    # Capture the print output
-    captured = capsys.readouterr()
-
-    # Check that the correct informational message is printed
+    # Capture the log output
+    captured = caplog.records[0].message
+    # Check that the correct informational message is logged
     assert (
-        captured.out
+        captured
         == f"Schema validation failed for pipeline `test_invalid_pipeline` "
         f"loaded from {test_invalid_pipeline_config_file}. See detailed error "
-        "below.\n"
+        "below."
     )


### PR DESCRIPTION
This PR adds a logger for Aineko so we can properly log instead of printing messages, warnings and errors.
This logging works independently from the AbstractNode log method.

Example with logging:
```
2023-11-02 14:10:24.247 - aineko - INFO - Application is starting.
2023-11-02 14:10:24.260 - aineko.core.runner - INFO - Creating dataset: example_pipeline.refresh_environment: {'type': 'kafka_stream'}
2023-11-02 14:10:24.260 - aineko.core.runner - INFO - Creating dataset: example_pipeline.webhook_events: {'type': 'kafka_stream'}
2023-11-02 14:10:24.260 - aineko.core.runner - INFO - Creating dataset: example_pipeline.user_actions: {'type': 'kafka_stream'}
2023-11-02 14:10:24.260 - aineko.core.runner - INFO - Creating dataset: example_pipeline.rerun_workflow: {'type': 'kafka_stream'}
2023-11-02 14:10:24.260 - aineko.core.runner - INFO - Creating dataset: example_pipeline.new_project: {'type': 'kafka_stream'}
2023-11-02 14:10:24.260 - aineko.core.runner - INFO - Creating dataset: example_pipeline.state_update: {'type': 'kafka_stream'}
2023-11-02 14:10:24.260 - aineko.core.runner - INFO - Creating dataset: logging: {'type': 'kafka_stream', 'params': {'num_partitions': 1, 'replication_factor': 1, 'config': {'retention.ms': 604800000}}}
2023-11-02 14:10:24.278 - aineko.core.runner - INFO - All datasets created.
```

And without logging:
```
Creating dataset: example_pipeline.refresh_environment: {'type': 'kafka_stream'}
Creating dataset: example_pipeline.webhook_events: {'type': 'kafka_stream'}
Creating dataset: example_pipeline.user_actions: {'type': 'kafka_stream'}
Creating dataset: example_pipeline.rerun_workflow: {'type': 'kafka_stream'}
Creating dataset: example_pipeline.new_project: {'type': 'kafka_stream'}
Creating dataset: example_pipeline.state_update: {'type': 'kafka_stream'}
Creating dataset: logging: {'type': 'kafka_stream', 'params': {'num_partitions': 1, 'replication_factor': 1, 'config': {'retention.ms': 604800000}}}
All datasets created.
```