### PR TITLE
fix: remove author prompt in cookiecutter

### DIFF
--- a/aineko/templates/first_aineko_pipeline/cookiecutter.json
+++ b/aineko/templates/first_aineko_pipeline/cookiecutter.json
@@ -2,7 +2,6 @@
     "project_name": "My Awesome Pipeline",
     "project_slug": "{{ cookiecutter.project_name.lower()|replace(' ', '_')|replace('-', '_')|replace('.', '_')|trim() }}",
     "project_description": "Behold my awesome pipeline!",
-    "authors": "John Doe <johndoe@gmail.com>",
     "pipeline_slug": "test-aineko-pipeline",
     "_deployment_config": false
 }

--- a/aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml
@@ -2,7 +2,7 @@
 name = "{{cookiecutter.project_slug}}"
 version = "0.0.0"
 description = "{{cookiecutter.project_description}}"
-authors = ["{{cookiecutter.authors}}"]
+authors = ["Jane Smith <janesmith@example.org>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
This PR removes the prompt to add the author information.
Reason: user feedback indicates that they don't necessarily want to use their email address or run into errors if they don't follow the exact syntax required by Poetry.

Closes #53