### PR TITLE
fix: logger entry point should be in __init__

### DIFF
--- a/aineko/__init__.py
+++ b/aineko/__init__.py
@@ -6,6 +6,8 @@
 __version__ = "0.2.0"
 __author__ = "Convex Labs Engineering"
 
+import logging
+
 from aineko.core.config_loader import ConfigLoader
 from aineko.core.dataset import (
     DatasetConsumer,
@@ -15,3 +17,15 @@ from aineko.core.dataset import (
 )
 from aineko.core.node import AbstractNode
 from aineko.core.runner import Runner
+
+
+def _setup_logging() -> None:
+    """Setup logging for the application."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s.%(msecs)d - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+_setup_logging()

--- a/aineko/__main__.py
+++ b/aineko/__main__.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Aineko command line interface."""
 import argparse
-import logging
 
 from aineko import __version__
 from aineko.cli.create_pipeline import create_pipeline_directory
@@ -10,15 +9,6 @@ from aineko.cli.docker_cli_wrapper import DockerCLIWrapper
 from aineko.cli.kafka_cli_wrapper import KafkaCLIWrapper
 from aineko.cli.run import main as run_main
 from aineko.cli.visualize import render_mermaid_graph
-
-
-def _setup_logging() -> None:
-    """Setup logging for the application."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s.%(msecs)d - %(name)s - %(levelname)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
 
 
 def _create_parser(subparser: argparse._SubParsersAction) -> None:
@@ -219,7 +209,4 @@ def _cli() -> None:
 
 
 if __name__ == "__main__":
-    _setup_logging()
-    logger = logging.getLogger("aineko")
-    logger.info("Application is starting.")
     _cli()

--- a/aineko/cli/run.py
+++ b/aineko/cli/run.py
@@ -23,6 +23,7 @@ def main(
         pipeline_name: Name of the pipeline to run, overrides pipeline config
         retry: If true, retry running the pipeline on failure every 10 seconds
     """
+    logger.info("Application is starting.")
     while True:
         try:
             runner = Runner(


### PR DESCRIPTION
This PR fixes a bug where no log statements are created when running aineko as a standalone CLI (`aineko run conf/pipeline.yml`) , whereas they would be created when running `python -m aineko run conf/pipeline.yml` 