### PR TITLE
docs: add page to explain how to configure kafka

### DIFF
--- a/docs/developer_guide/config_kafka.md
+++ b/docs/developer_guide/config_kafka.md
@@ -1,0 +1,16 @@
+# Configuring Kafka
+
+Aineko uses [`kafka`](https://kafka.apache.org/documentation/) under the hood for sending messages between nodes. As part of running Aineko locally, we recommend running a local `kafka` and `zookeeper` server using
+
+```
+poetry run aineko service start
+```
+
+To use a different `kafka` cluster, such as in deployment settings, we allow for configuring of `kafka` parameters through environment variables. Typically, you would want to modify configuration for the [consumer](https://kafka.apache.org/documentation/#consumerconfigs) and [producer](https://kafka.apache.org/documentation/#producerconfigs) to point to the desired cluster.
+
+See below for default `kafka` configuration that ships with `aineko` and how to override them.
+
+::: aineko.config
+    options:
+        members:
+            - DEFAULT_KAFKA_CONFIG


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
This adds a docs page to explain how users can configure kafka settings to use their own clusters.

## Motivation
<!-- Describe the motivation for this change. -->
Users might want to use their own kafka clusters and set aineko to use it.

## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [ ] Status checks pass.
- [ ] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [x] Title is accurate and formatted appropriately.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
