### PR TITLE
fix: name of cli function in template pyproject.toml

### DIFF
--- a/aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml
@@ -14,4 +14,4 @@ pytest = "^7.4.1"
 pytest-cov = "^4.1.0"
 
 [tool.poetry.scripts]
-aineko = "aineko.__main__:_cli"
+aineko = "aineko.__main__:cli"


### PR DESCRIPTION
the new cli function is called `cli` and replaces an old function called `_cli`. 

This needs to be updated for new projects in the template repo

## Summary
<!-- Describe the changes in this PR. -->
changed the name of the cli command function in the template pyproject.toml file.

## Motivation
<!-- Describe the motivation for this change. -->
Previously, the default command when calling `aineko` from the terminal was `_cli`, but now the function has been renamed `cli`. 

## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
