### PR TITLE
fix: remove unneeded poetry setting

### DIFF
--- a/aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml
@@ -12,6 +12,3 @@ aineko = "0.2.3"
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.1"
 pytest-cov = "^4.1.0"
-
-[tool.poetry.scripts]
-aineko = "aineko.__main__:_cli"


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
This PR removes the unneeded poetry script referencing the Aineko CLI.

## Motivation
<!-- Describe the motivation for this change. -->
This setting is only needed when the script is part of the package, not for one of it's dependencies.

Closes #78 

## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
