### PR TITLE
fix: cli unconventional "-h" usage & add "-h" as valid help option

### DIFF
--- a/aineko/__main__.py
+++ b/aineko/__main__.py
@@ -11,7 +11,7 @@ from aineko.cli.run import run
 from aineko.cli.visualize import visualize
 
 
-@click.group("aineko")
+@click.group("aineko", context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(__version__)
 def cli() -> None:
     """Aineko CLI."""

--- a/aineko/cli/docker_cli_wrapper.py
+++ b/aineko/cli/docker_cli_wrapper.py
@@ -162,7 +162,7 @@ def down(ctx: Context) -> None:
 
 @service.command()
 @click.option(
-    "-h",
+    "-H",
     "--hard",
     is_flag=True,
     help=(


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
This PR adds the `-h` option as a valid alternative to `--help`, as suggested in  #84 
We also replace the unconventional use of `-h` for the `--hard` flag in aineko service with `-H`.

## Motivation
<!-- Describe the motivation for this change. -->
Using `-h `for anything other than a shorthand flag for `--help` is unconventional.


## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
