### PR TITLE
chore: make integration tests depend on python-checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,11 @@ workflows:
           prj_dir: aineko
           python_version: << pipeline.parameters.python_version >>
           markers: integration
-      - test-aineko-create
+          requires:
+            - python-checks
+      - test-aineko-create:
+          requires:
+            - python-checks
 
   publish-docs:
     jobs:


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
This PR makes the integration tests depend on the python-checks in CircleCI. This will result in only running these tests if the python-checks pass. 

## Motivation
<!-- Describe the motivation for this change. -->
As suggested in https://github.com/aineko-dev/aineko/pull/92#discussion_r1398478886

## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
