### PR TITLE
refactor: rename catch_exception and make it internal

### DIFF
--- a/aineko/core/node.py
+++ b/aineko/core/node.py
@@ -212,14 +212,10 @@ class AbstractNode(ABC):
             out_msg
         )
 
-    def catch_exception(self) -> None:
-        """Catch an exception and report it.
-
-        Args:
-            exc: Exception to catch
-        """
+    def _log_traceback(self) -> None:
+        """Logs the traceback of an exception."""
         exc_info = traceback.format_exc()
-        self.log(exc_info, level="error")
+        self.log(exc_info, level="debug")
 
     def execute(self, params: Optional[dict] = None) -> None:
         """Execute the node.
@@ -235,7 +231,7 @@ class AbstractNode(ABC):
         try:
             self._pre_loop_hook(params)
         except Exception:  # pylint: disable=broad-except
-            self.catch_exception()
+            self._log_traceback()
             raise
 
         while run_loop is not False:
@@ -243,7 +239,7 @@ class AbstractNode(ABC):
             try:
                 run_loop = self._execute(params)  # type: ignore
             except Exception:  # pylint: disable=broad-except
-                self.catch_exception()
+                self._log_traceback()
                 raise
 
         self.log(f"Execution loop complete for node: {self.__class__.__name__}")


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
* Rename catch_exception to _log_traceback
* Make it an internal method
* log to debug instead of error

## Motivation
<!-- Describe the motivation for this change. -->
I think the original name is misleading as it does not "catch" an exception.


## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
