### PR TITLE
fix: remove docker-compose.yml from docs

### DIFF
--- a/docs/developer_guide/aineko_project.md
+++ b/docs/developer_guide/aineko_project.md
@@ -14,7 +14,6 @@ description: A closer look into how a pipeline is defined and some CLI commands
 ├── README.md
 ├── conf
 │   └── pipeline.yml
-├── docker-compose.yml
 ├── my_awesome_pipeline
 │   ├── __init__.py
 │   ├── config.py
@@ -32,7 +31,6 @@ Let's zoom in on the more interesting files to take note of:
 
 1. **`conf/pipeline.yml`** - This contains your pipeline definition that you are expected to modify to define your own pipeline. It is defined in YAML.
 2. **`my_awesome_pipeline/nodes.py`** - Remember how nodes are abstractions for computations? These nodes are implemented in Python. You do not have to strictly define them in this file. You can define them anywhere you like within the directory as long as you reference them correctly in `pipeline.yml`.
-3. **`docker-compose.yml`** - When we invoke `aineko run` , datasets has to be initialised - which means that we need to create Kafka topics. This file contains the image we need to create containers from, as well as other configurations like environment variables and network settings. _You typically do not have to change this file._
 
 ## Defining a Pipeline
 


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
Remove the docker-compose reference in the docs.

## Motivation
<!-- Describe the motivation for this change. -->
No docker-compose file is shipped anymore. This has been internalised.


## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
