### PR TITLE
Feat: aineko dream CLI

### DIFF
--- a/aineko/__main__.py
+++ b/aineko/__main__.py
@@ -6,6 +6,7 @@ import click
 from aineko import __version__
 from aineko.cli.create_pipeline import create
 from aineko.cli.docker_cli_wrapper import service
+from aineko.cli.dream import dream
 from aineko.cli.kafka_cli_wrapper import stream
 from aineko.cli.run import run
 from aineko.cli.visualize import visualize
@@ -23,6 +24,7 @@ cli.add_command(run)
 cli.add_command(service)
 cli.add_command(stream)
 cli.add_command(visualize)
+cli.add_command(dream)
 
 if __name__ == "__main__":
     cli(obj={})

--- a/aineko/cli/dream.py
+++ b/aineko/cli/dream.py
@@ -34,7 +34,13 @@ def dream(prompt: str, api_key: str, url: str) -> None:
         )
         click.echo(f"Received response code: {r.status_code}")
         if r.status_code == 200:
-            click.echo(r.json()["status"])
+            request_id = r.json()["request_id"]
+            click.echo(
+                "Successfully published project to: "
+                f"https://github.com/Convex-Labs/dream-catcher/tree/{request_id}. \n\n"  # pylint: disable=line-too-long
+                "To create a new project from this dream, run: \n\n"
+                f"aineko create --repo Convex-Labs/dream-catcher#{request_id}"
+            )
         else:
             click.echo(r.text)
 

--- a/aineko/cli/dream.py
+++ b/aineko/cli/dream.py
@@ -1,0 +1,44 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+"""A wrapper around API calls to the Aineko Dream API."""
+
+import click
+import requests
+
+
+@click.command()
+@click.argument("prompt")
+@click.argument("api-key")
+@click.option(
+    "-u",
+    "--url",
+    default="https://dream.ap-2359264f-9cba-43ba-9ac4-ae3ba7b1d4b1.aineko.app",
+    help="API url to use for the Aineko Dream API.",
+)
+def dream(prompt: str, api_key: str, url: str) -> None:
+    """Main function generate an aineko project using Aineko Dream.\f
+
+    Args:
+        prompt: Prompt to generate a project from.
+        api_key: API key to use for the Aineko Dream API.
+        url: URL to use for the Aineko Dream API.
+    """
+    try:
+        click.echo("Generating project from prompt...")
+
+        r = requests.get(
+            url=f"{url}/create/",
+            params={"prompt": prompt},
+            headers={"x-api-key": api_key},
+            timeout=300,
+        )
+        click.echo(f"Received response code: {r.status_code}")
+        if r.status_code == 200:
+            click.echo(r.json()["status"])
+        else:
+            click.echo(r.text)
+
+    except Exception as e:
+        raise click.ClickException(
+            f"Error connecting to Aineko Dream API at {url}: {e}"
+        )

--- a/aineko/cli/dream.py
+++ b/aineko/cli/dream.py
@@ -16,7 +16,7 @@ import requests
     help="API url to use for the Aineko Dream API.",
 )
 def dream(prompt: str, api_key: str, url: str) -> None:
-    """Main function generate an aineko project using Aineko Dream.\f
+    """Main function to generate an aineko project using Aineko Dream.\f
 
     Args:
         prompt: Prompt to generate a project from.

--- a/docs/.styles/Vocab/Aineko/accept.txt
+++ b/docs/.styles/Vocab/Aineko/accept.txt
@@ -13,3 +13,5 @@ PoisonPill
 ChatGPT
 [Kk]afka
 CLI
+GitHub
+github

--- a/docs/aineko_dream.md
+++ b/docs/aineko_dream.md
@@ -12,7 +12,7 @@ poetry run aineko dream "create a pipeline that scrapes twitter and analyses the
 
 replacing `API-KEY` with a valid Aineko Dream API key. Contact support@aineko.dev to get an API key to try this feature.
 
-Aineko Dream goes on to create a complete aineko project, including node code, pipeline configuration and more using OpenAI's GPT-4 models. Upon completion, Aineko Dream publishes the project in the public Github repository [dream-catcher](https://github.com/Convex-Labs/dream-catcher).
+Aineko Dream goes on to create a complete aineko project, including node code, pipeline configuration and more using OpenAI's GPT-4 models. Upon completion, Aineko Dream publishes the project in the public GitHub repository [dream-catcher](https://github.com/Convex-Labs/dream-catcher).
 
 ## Creating your Aineko Dream project
 
@@ -22,5 +22,5 @@ Upon completion of the previous step, `aineko create` offers an easy way to get 
 poetry run aineko create --repo Convex-Labs/dream-catcher#12345
 ```
 
-where the argument after repo should be the unique ID associated to your generated project. This will be output in the result of the previous section.
+where the argument after `--repo` should be the unique ID associated to your generated project. This will be output in the result of the previous section.
 

--- a/docs/aineko_dream.md
+++ b/docs/aineko_dream.md
@@ -1,6 +1,6 @@
 # Aineko Dream
 
-Aineko Dream is the quickest way to get started with Aineko pipelines by leveraging the power of generative AI to create a starter Aineko pipeline based on your use case. 
+Aineko Dream leverages the power of generative AI to create a starter Aineko pipeline based on your use case. 
 
 ## Generating a Project
 

--- a/docs/aineko_dream.md
+++ b/docs/aineko_dream.md
@@ -1,0 +1,26 @@
+# Aineko Dream
+
+Aineko Dream is the quickest way to get started with Aineko pipelines by leveraging the power of generative AI to create a starter Aineko pipeline based on your use case. 
+
+## Generating a Project
+
+To generate a project, invoke the Aineko Dream CLI with a prompt with:
+
+```bash
+poetry run aineko dream "create a pipeline that scrapes twitter and analyses the results to identify trends" "API-KEY"
+```
+
+replacing `API-KEY` with a valid Aineko Dream API key. Contact support@aineko.dev to get an API key to try this feature.
+
+Aineko Dream goes on to create a complete aineko project, including node code, pipeline configuration and more using OpenAI's GPT-4 models. Upon completion, Aineko Dream publishes the project in the public Github repository [dream-catcher](https://github.com/Convex-Labs/dream-catcher).
+
+## Creating your Aineko Dream project
+
+Upon completion of the previous step, `aineko create` offers an easy way to get started. To initialize an aineko project using the generated files from the previous step, run
+
+```bash
+poetry run aineko create --repo Convex-Labs/dream-catcher#12345
+```
+
+where the argument after repo should be the unique ID associated to your generated project. This will be output in the result of the previous section.
+

--- a/docs/developer_guide/pipeline_configuration.md
+++ b/docs/developer_guide/pipeline_configuration.md
@@ -80,12 +80,12 @@ This section defines the compute nodes for a pipeline.
 A particular node instance in the pipeline, defined by a unique name. Any parameters defined at the individual node level will locally overwrite any default settings defined at the `default_node_settings` level.
 
 | Key           | Required | Type            | Description                                                                                                                                                           |
-| ------------- | -------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `class`       | Y        | string          | Python module to run for the node.                                                                                                                                    |
-| `inputs`      | N        | list of strings | Defines which datasets to consume from if applicable.                                                                                                                 |
-| `outputs`     | N        | list of strings | Defines which datasets to produce to if applicable.                                                                                                                   |
+| ------------- | -------- | --------------- |---------------------------------------------------------------------------------------- |
+| `class`       | Y        | string          | Python module to run for the node. This should exist within the python module in the same repository . |
+| `inputs`      | N        | list of strings | Defines which datasets to consume from if applicable. |
+| `outputs`     | N        | list of strings | Defines which datasets to produce to if applicable. |
 | `node_params` | N        | map             | Defines any arbitrary parameters relevant for node's application logic. In the example above, we defined `initial_state` and `increment` parameters, which are both integers. |
-| `num_cpus`    | Y        | float           | Number of CPUs allocated to a node. Required either for each node definition or at `default_node_settings` level.                                                     |
+| `num_cpus`    | Y        | float           | Number of CPUs allocated to a node. Required either for each node definition or at `default_node_settings` level.  |
 
 
 

--- a/docs/examples/aineko_dream.md
+++ b/docs/examples/aineko_dream.md
@@ -12,7 +12,7 @@ coverY: 189
 
 
 <a href="https://github.com/aineko-dev/aineko-dream" markdown>
-:fontawesome-brands-github: **View on Github**
+:fontawesome-brands-github: **View on GitHub**
 </a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="https://join.slack.com/t/aineko-dev/shared_invite/zt-23yuq8mrl-uZavRQKGFltxLZLCqcQZaQ" markdown>
 :fontawesome-brands-slack: **Try on Slack**

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,12 +44,17 @@ description: Fastest way to get an Aineko pipeline up and running
 
 ### Create a template pipeline with the CLI
 
+!!! tip "Create a pipeline using Aineko Dream"
+
+    Interested in creating a custom pipeline for a specific use case? Leverage Aineko Dream to generate a pipeline based on a prompt that describes your use case. See more detail [here](./aineko_dream.md)
+
 You will see the following prompts as `aineko` tries to create a project directory containing the boilerplate you need for a pipeline. Feel free to use the defaults suggested.
 
 :   
     ```
     $ aineko create
-
+    ```
+    ```
     [1/4] project_name (My Awesome Pipeline):
     [2/4] project_slug (my_awesome_pipeline):
     [3/4] project_description (Behold my awesome pipeline!):
@@ -69,7 +74,8 @@ You will see the following prompts as `aineko` tries to create a project directo
 :   
     ```
     $ poetry run aineko service start
-
+    ```
+    ```
     Container zookeeper  Creating
     Container zookeeper  Created
     Container broker  Creating
@@ -85,7 +91,8 @@ You will see the following prompts as `aineko` tries to create a project directo
 :   
     ```
     $ poetry run aineko run ./conf/pipeline.yml
-
+    ```
+    ```
     INFO - Application is starting.
     INFO - Creating dataset: aineko-pipeline.sequence: {'type': 'kafka_stream'}
     INFO - All datasets created.
@@ -99,7 +106,8 @@ To view messages running in one of the user-defined datasets:
 :   
     ```
     $ poetry run aineko stream --dataset test-aineko-pipeline.test_sequence --from-beginning
-
+    ```
+    ```
     {"timestamp": "2023-11-10 17:27:20", "dataset": "sequence", "source_pipeline": "test-aineko-pipeline", "source_node": "sequence", "message": 1}
     {"timestamp": "2023-11-10 17:27:20", "dataset": "sequence", "source_pipeline": "test-aineko-pipeline", "source_node": "sequence", "message": 2}
     ```
@@ -109,7 +117,8 @@ Alternatively, to view logs stored in the built-in `logging` dataset:
 :   
     ```
     $ poetry run aineko stream --dataset logging --from-beginning
-
+    ```
+    ```
     {"timestamp": "2023-11-10 17:46:15", "dataset": "logging", "source_pipeline": "test-aineko-pipeline", "source_node": "sum", "message": {"log": "Received input: 1. Adding 1...", "level": "info"}}
     ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
   - Get Started:
       - 'index.md'
       - 'quickstart.md'
+      - 'aineko_dream.md'
       - 'contributing.md'
       - 'contributing_docs.md'
   - Developer Guide:


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
The PR adds an `aineko dream` CLI command that queries the Aineko Dream API to generate a pipeline. Changes are made on top of #104 , merge that first.

To use, 
```
poetry run aineko dream "prompt here" "API_KEY_HERE" --url https://dream-dev.ap-2359264f-9cba-43ba-9ac4-ae3ba7b1d4b1.aineko.app
```

optionally, the `--url` option to use is used to specify the dev version of the Aineko Dream API. It defaults to the production version when nothing is specified.

## Motivation
<!-- Describe the motivation for this change. -->
The Aineko Dream API should be integrated to Aineko CLI.

## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [ ] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
