### PR TITLE
fixes: mkdocs-material repo, docs, endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,10 @@ parameters:
     description: Version to python to use
     type: string
     default: "3.10"
+  mkdocs_material_version:
+    description: Version of mkdocs-material-insiders to use
+    type: string
+    default: "9.4.14-insiders-4.46.0"
 
 orbs:
   vale: circleci/vale@1.1.1
@@ -165,6 +169,8 @@ jobs:
             - "44:55:52:46:cf:d7:60:1d:8e:99:d4:f8:e8:8b:45:d2"
       - checkout
       - run: poetry install --with docs --no-interaction --quiet
+      - run: poetry add git+ssh://git@github.com/squidfunk/mkdocs-material-insiders.git#<<
+          pipeline.parameters.mkdocs_material_version >> --group docs
       - run: git config user.name aineko-ci
       - run: git config user.email engineering-admins@convexlabs.xyz
       - run: |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For complete information please refer to the [Aineko documentation](https://docs
 
 ## Quickstart
 
-Get started with Aineko in minutes by following [this tutorial](https://docs.aineko.dev/0.2/quickstart/).
+Get started with Aineko in minutes by following [this tutorial](https://docs.aineko.dev/latest/start/quickstart/).
 
 ## Examples
 

--- a/aineko/__init__.py
+++ b/aineko/__init__.py
@@ -3,7 +3,7 @@
 """Package information for the Aineko package."""
 
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 __author__ = "Convex Labs Engineering"
 
 import logging

--- a/aineko/cli/dream.py
+++ b/aineko/cli/dream.py
@@ -12,7 +12,7 @@ import requests
 @click.option(
     "-u",
     "--url",
-    default="https://dream.ap-2359264f-9cba-43ba-9ac4-ae3ba7b1d4b1.aineko.app",
+    default="https://dream.ap-6d356ccd-bfba-4110-994a-fe164ab8bf77.aineko.app",
     help="API url to use for the Aineko Dream API.",
 )
 def dream(prompt: str, api_key: str, url: str) -> None:

--- a/aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.11"
-aineko = "0.2.5"
+aineko = "0.2.6"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.1"

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -17,8 +17,8 @@ Then, install the source code for Aineko on your local system.
 
 :   
     ```bash
-    git clone https://github.com/Aineko-dev/Aineko
-    cd Aineko && poetry install --with dev,test,docs
+    git clone https://github.com/aineko-dev/aineko
+    cd aineko && poetry install --with dev,test,docs
     ```
 
 ## Make your changes to Aineko source code

--- a/docs/extras/fastapi.md
+++ b/docs/extras/fastapi.md
@@ -5,7 +5,7 @@ The FastAPI extra node can be used by adding the following to `pyproject.toml`
 :   
     ```yaml title="pyproject.toml" hl_lines="2"
     [tool.poetry.dependencies]
-    aineko = {version = "^0.2.5", extras=["fastapi"]}
+    aineko = {version = "^0.2.6", extras=["fastapi"]}
     ```
 
 ## API Reference

--- a/docs/extras/index.md
+++ b/docs/extras/index.md
@@ -12,7 +12,7 @@ To install the dependencies of an extra node submodule, modify your `pyproject.t
     ```yaml title="pyproject.toml" hl_lines="3"
     [tool.poetry.dependencies]
     python = ">=3.10,<3.11"
-    aineko = {version = "^0.2.5", extras=["fastapi"]}
+    aineko = {version = "^0.2.6", extras=["fastapi"]}
     ```
 
 Once added, install the required dependencies using 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1570,19 +1570,20 @@ files = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.4.14+insiders.4.46.0"
+version = "9.4.14"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
-files = []
-develop = false
+files = [
+    {file = "mkdocs_material-9.4.14-py3-none-any.whl", hash = "sha256:dbc78a4fea97b74319a6aa9a2f0be575a6028be6958f813ba367188f7b8428f6"},
+    {file = "mkdocs_material-9.4.14.tar.gz", hash = "sha256:a511d3ff48fa8718b033e7e37d17abd9cc1de0fdf0244a625ca2ae2387e2416d"},
+]
 
 [package.dependencies]
 babel = ">=2.10,<3.0"
 colorama = ">=0.4,<1.0"
 jinja2 = ">=3.0,<4.0"
 markdown = ">=3.2,<4.0"
-mergedeep = ">=1.3,<2.0"
 mkdocs = ">=1.5.3,<2.0"
 mkdocs-material-extensions = ">=1.3,<2.0"
 paginate = ">=0.5,<1.0"
@@ -1592,15 +1593,9 @@ regex = ">=2022.4"
 requests = ">=2.26,<3.0"
 
 [package.extras]
-git = ["mkdocs-git-committers-plugin-2 (>=2.2,<3.0)", "mkdocs-git-revision-date-localized-plugin (>=1.2,<2.0)"]
+git = ["mkdocs-git-committers-plugin-2 (>=1.1,<2.0)", "mkdocs-git-revision-date-localized-plugin (>=1.2,<2.0)"]
 imaging = ["cairosvg (>=2.6,<3.0)", "pillow (>=9.4,<10.0)"]
 recommended = ["mkdocs-minify-plugin (>=0.7,<1.0)", "mkdocs-redirects (>=1.2,<2.0)", "mkdocs-rss-plugin (>=1.6,<2.0)"]
-
-[package.source]
-type = "git"
-url = "ssh://git@github.com/squidfunk/mkdocs-material-insiders.git"
-reference = "9.4.14-insiders-4.46.0"
-resolved_reference = "199b01479f8770cee3a3b3456edf0103c68bd468"
 
 [[package]]
 name = "mkdocs-material-extensions"
@@ -3569,4 +3564,4 @@ fastapi = ["fastapi", "uvicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.11"
-content-hash = "fe2b86dc6830ff26c5d2f7acab60a43e222b4658c833878faa47d189566e6a53"
+content-hash = "16fa6e0ca78a650a88ce8d879ceb371bca30717f3817c55affb0810a21a6873c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ pydocstyle = "^6.3.0"
 optional = true
 
 [tool.poetry.group.docs.dependencies]
-mkdocs-material = {git = "ssh://git@github.com/squidfunk/mkdocs-material-insiders.git", rev = "9.4.14-insiders-4.46.0"}
+mkdocs-material = "9.4.14"
 mkdocs-glightbox = "^0.3.4"
 mkdocstrings = { extras = ["python"], version = "^0.23.0" }
 mkdocs-click = "^0.8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 
 [tool.poetry]
 name = "aineko"
-version = "0.2.5"
+version = "0.2.6"
 description = "Aineko, a data integration framework."
 authors = ["Convex Labs <engineering-admins@convexlabs.xyz>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->

This PR fixes:
- endpoint used for Aineko Dream API
- mkdocs-material version in pyproject (use public instead of public, and load private during docs publishing)
- links and references in docs

## Motivation
<!-- Describe the motivation for this change. -->


## Author Checklist

- [ ] Changes are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Documentation is updated if necessary.
- [ ] Status checks pass.
- [ ] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
