### PR TITLE
feat: add error handling for invalid offset

### DIFF
--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -21,7 +21,6 @@ e.g. message:
 import datetime
 import json
 import logging
-import time
 from typing import Any, Dict, Literal, Optional
 
 from confluent_kafka import (  # type: ignore

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -212,7 +212,7 @@ class DatasetConsumer:
                     self.name,
                     e,
                 )
-                return
+                return None
             message = self.consumer.poll(timeout=timeout)
 
         self.cached = True

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -160,15 +160,14 @@ class DatasetConsumer:
             )[1]
 
             # Invalid high offset can be caused by various reasons,
-            # including rebalancing and empty topic.
+            # including rebalancing and empty topic. Default to -1.
             if high_offset == OFFSET_INVALID:
                 logger.error(
                     "Invalid offset received for consumer: %s", self.name
                 )
-                self.cached = False
-                return
-
-            partition.offset = high_offset - 1
+                partition.offset = -1
+            else:
+                partition.offset = high_offset - 1
 
         self.consumer.assign(partitions)
 

--- a/tests/conf/integration_test_empty_dataset.yml
+++ b/tests/conf/integration_test_empty_dataset.yml
@@ -1,0 +1,21 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+pipeline:
+  name: integration_test_kafka_edge_cases
+
+  default_node_settings:
+    num_cpus: 0.5
+
+  nodes:
+    write:
+      class: tests.integration.test_kafka_edge_cases.ConsumerNode
+      inputs:
+        - messages
+      outputs:
+        - test_result
+
+  datasets:
+    messages:
+      type: kafka_stream
+    test_result:
+      type: kafka_stream

--- a/tests/integration/test_kafka_edge_cases.py
+++ b/tests/integration/test_kafka_edge_cases.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Tests edge cases to do with kafka clusters."""
+
+import time
+from typing import Optional
+
+import ray
+
+from aineko import AbstractNode, DatasetConsumer, Runner
+
+
+class ConsumerNode(AbstractNode):
+    """Node that consumes message using different consume methods."""
+
+    def _execute(self, params: Optional[dict] = None) -> None:
+        """Consumes message."""
+        self.consumers["messages"].consume(how="next")
+        self.consumers["messages"].consume(how="last", timeout=1)
+        self.producers["test_result"].produce("OK")
+        self.producers["test_result"].produce("END")
+        time.sleep(1)
+        self.activate_poison_pill()
+        return False
+
+
+def test_consume_empty_datasets():
+    """Integration test that checks that empty datasets do not cause errors.
+
+    If a dataset is empty, dataset consumer methods should not error out.
+    """
+    runner = Runner(
+        pipeline_config_file="tests/conf/integration_test_empty_dataset.yml",
+    )
+    try:
+        runner.run()
+    except ray.exceptions.RayActorError:
+        consumer = DatasetConsumer(
+            dataset_name="test_result",
+            node_name="consumer",
+            pipeline_name="integration_test_kafka_edge_cases",
+            dataset_config={},
+            has_pipeline_prefix=True,
+        )
+        count_messages = consumer.consume_all(end_message="END")
+        assert count_messages[0]["message"] == "OK"

--- a/tests/integration/test_kafka_edge_cases.py
+++ b/tests/integration/test_kafka_edge_cases.py
@@ -37,12 +37,15 @@ def test_consume_empty_datasets():
     try:
         runner.run()
     except ray.exceptions.RayActorError:
-        consumer = DatasetConsumer(
-            dataset_name="test_result",
-            node_name="consumer",
-            pipeline_name="integration_test_kafka_edge_cases",
-            dataset_config={},
-            has_pipeline_prefix=True,
-        )
-        count_messages = consumer.consume_all(end_message="END")
-        assert count_messages[0]["message"] == "OK"
+        # This is expected because we activated the poison pill
+        pass
+
+    consumer = DatasetConsumer(
+        dataset_name="test_result",
+        node_name="consumer",
+        pipeline_name="integration_test_kafka_edge_cases",
+        dataset_config={},
+        has_pipeline_prefix=True,
+    )
+    count_messages = consumer.consume_all(end_message="END")
+    assert count_messages[0]["message"] == "OK"

--- a/tests/integration/test_kafka_edge_cases.py
+++ b/tests/integration/test_kafka_edge_cases.py
@@ -5,6 +5,7 @@
 import time
 from typing import Optional
 
+import pytest
 import ray
 
 from aineko import AbstractNode, DatasetConsumer, Runner
@@ -24,6 +25,7 @@ class ConsumerNode(AbstractNode):
         return False
 
 
+@pytest.mark.integration
 def test_consume_empty_datasets():
     """Integration test that checks that empty datasets do not cause errors.
 


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
Add error handling where we skip attempting to assign partition offsets if they are invalid.

## Motivation
<!-- Describe the motivation for this change. -->
Issues were observed where deployments could not assign partitions when the `get_watermark_offsets` method was returning invalid offset values.

## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [ ] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
