### PR TITLE
chore: upgrade typehints to py310

### DIFF
--- a/.internals/check_license.py
+++ b/.internals/check_license.py
@@ -18,7 +18,7 @@ def check_license(filename: str) -> bool:
     Returns:
         True if the license snippet is present and correct, False otherwise.
     """
-    with open(filename, "r", encoding="utf-8") as f:
+    with open(filename, encoding="utf-8") as f:
         lines = [f.readline().strip() for _ in range(2)]
         return "\n".join(lines) == LICENSE_SNIPPET.strip()
 

--- a/aineko/cli/docker_cli_wrapper.py
+++ b/aineko/cli/docker_cli_wrapper.py
@@ -3,7 +3,6 @@
 """A wrapper class that executes Docker CLI commands via subprocess."""
 import subprocess
 import sys
-from typing import Optional
 
 import click
 from click.core import Context
@@ -57,7 +56,7 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
 """
 
-    def __init__(self, custom_config_path: Optional[str] = None) -> None:
+    def __init__(self, custom_config_path: str | None = None) -> None:
         """Initialize DockerCLIWrapper class."""
         if custom_config_path:
             self._load_custom_config(custom_config_path)
@@ -114,9 +113,7 @@ services:
             custom_config_path: Path to the custom Docker Compose config file.
         """
         try:
-            with open(
-                file=custom_config_path, mode="r", encoding="utf-8"
-            ) as file:
+            with open(file=custom_config_path, encoding="utf-8") as file:
                 cls._docker_compose_config = file.read()
         except FileNotFoundError:
             print(
@@ -133,7 +130,7 @@ services:
     help="Path to the custom Docker Compose config file.",
 )
 @click.pass_context
-def service(ctx: Context, config: Optional[str] = None) -> None:
+def service(ctx: Context, config: str | None = None) -> None:
     """Manage Aineko docker services (Kafka and Zookeeper containers)."""
     ctx.ensure_object(dict)
     ctx.obj["config"] = config

--- a/aineko/cli/run.py
+++ b/aineko/cli/run.py
@@ -4,7 +4,6 @@
 import logging
 import time
 import traceback
-from typing import Optional
 
 import click
 
@@ -28,7 +27,7 @@ logger = logging.getLogger(__name__)
 )
 def run(
     pipeline_config_file: str,
-    pipeline_name: Optional[str] = None,
+    pipeline_name: str | None = None,
     retry: bool = False,
 ) -> None:
     """Main function to run a pipeline from the command line.\f

--- a/aineko/cli/visualize.py
+++ b/aineko/cli/visualize.py
@@ -69,7 +69,7 @@ def build_mermaid_from_yaml(
     Returns:
         A mermaid graph as a string.
     """
-    with open(config_path, "r", encoding="utf-8") as f:
+    with open(config_path, encoding="utf-8") as f:
         text = f.read()
     root = yaml.safe_load(text)
     pipeline_name = next(iter(root))

--- a/aineko/config.py
+++ b/aineko/config.py
@@ -22,7 +22,7 @@ corresponds to `bootstrap.servers`.
 import copy
 import json
 import os
-from typing import Any, Dict
+from typing import Any
 
 
 # pylint: disable=too-few-public-methods
@@ -63,13 +63,13 @@ class DEFAULT_KAFKA_CONFIG(BaseConfig):
             BROKER_CONFIG[config] = value
 
     # Config for default kafka consumer
-    CONSUMER_CONFIG: Dict[str, str] = {
+    CONSUMER_CONFIG: dict[str, str] = {
         **BROKER_CONFIG,
         "auto.offset.reset": "earliest",
     }
 
     # Config for default kafka producer
-    PRODUCER_CONFIG: Dict[str, str] = {**BROKER_CONFIG}
+    PRODUCER_CONFIG: dict[str, str] = {**BROKER_CONFIG}
 
     # Default dataset config
     DATASET_PARAMS = {

--- a/aineko/core/config_loader.py
+++ b/aineko/core/config_loader.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Module to load config files."""
 import logging
-from typing import Union, overload
+from typing import overload
 
 from pydantic import ValidationError
 
@@ -81,8 +81,8 @@ class ConfigLoader:
         ...
 
     def _update_params(
-        self, value: Union[dict, list, str, int], params: dict
-    ) -> Union[dict, list, str, int]:
+        self, value: dict | list | str | int, params: dict
+    ) -> dict | list | str | int:
         """Update value with params.
 
         Recursively calls the method if value is a list or dictionary until it

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -21,7 +21,7 @@ e.g. message:
 import datetime
 import json
 import logging
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Literal
 
 from confluent_kafka import (  # type: ignore
     OFFSET_INVALID,
@@ -75,9 +75,9 @@ class DatasetConsumer:
         dataset_name: str,
         node_name: str,
         pipeline_name: str,
-        dataset_config: Dict[str, Any],
-        bootstrap_servers: Optional[str] = None,
-        prefix: Optional[str] = None,
+        dataset_config: dict[str, Any],
+        bootstrap_servers: str | None = None,
+        prefix: str | None = None,
         has_pipeline_prefix: bool = False,
     ):
         """Initialize the consumer."""
@@ -116,8 +116,8 @@ class DatasetConsumer:
 
     @staticmethod
     def _validate_message(
-        message: Optional[Message] = None,
-    ) -> Optional[dict]:
+        message: Message | None = None,
+    ) -> dict | None:
         """Checks if a message is valid and converts it to appropriate format.
 
         Args:
@@ -173,8 +173,8 @@ class DatasetConsumer:
     def consume(
         self,
         how: Literal["next", "last"] = "next",
-        timeout: Optional[float] = None,
-    ) -> Optional[dict]:
+        timeout: float | None = None,
+    ) -> dict | None:
         """Polls a message from the dataset.
 
         If the consume method is last but the method encounters
@@ -220,7 +220,7 @@ class DatasetConsumer:
         return self._validate_message(message)
 
     def _consume_message(
-        self, how: Literal["next", "last"], timeout: Optional[float] = None
+        self, how: Literal["next", "last"], timeout: float | None = None
     ) -> dict:
         """Calls the consume method and blocks until a message is returned.
 
@@ -334,8 +334,8 @@ class DatasetProducer:
         dataset_name: str,
         node_name: str,
         pipeline_name: str,
-        dataset_config: Dict[str, Any],
-        prefix: Optional[str] = None,
+        dataset_config: dict[str, Any],
+        prefix: str | None = None,
         has_pipeline_prefix: bool = False,
     ):
         """Initialize the producer."""
@@ -381,7 +381,7 @@ class DatasetProducer:
         if err is not None:
             logger.error("Message %s delivery failed: %s", message, err)
 
-    def produce(self, message: dict, key: Optional[str] = None) -> None:
+    def produce(self, message: dict, key: str | None = None) -> None:
         """Produce a message to the dataset.
 
         Args:
@@ -440,8 +440,8 @@ class FakeDatasetConsumer:
     def consume(
         self,
         how: str = "next",
-        timeout: Optional[float] = None,
-    ) -> Optional[dict]:
+        timeout: float | None = None,
+    ) -> dict | None:
         """Reads a message from the dataset.
 
         Args:
@@ -477,7 +477,7 @@ class FakeDatasetConsumer:
 
         return None
 
-    def next(self) -> Optional[dict]:
+    def next(self) -> dict | None:
         """Wraps `consume(how="next")`, blocks until available.
 
         Returns:
@@ -485,7 +485,7 @@ class FakeDatasetConsumer:
         """
         return self.consume(how="next")
 
-    def last(self, timeout: float = 1) -> Optional[dict]:
+    def last(self, timeout: float = 1) -> dict | None:
         """Wraps `consume(how="last")`, blocks until available.
 
         Returns:

--- a/aineko/core/deploy_config_loader.py
+++ b/aineko/core/deploy_config_loader.py
@@ -13,7 +13,6 @@ of truth in which infrastructure should be deployed from.
 """
 
 from collections import defaultdict
-from typing import Optional
 
 from pydantic.v1.utils import deep_update
 
@@ -68,7 +67,7 @@ def generate_deploy_config(
 
 
 def _generate_full_config(
-    user_config: Optional[DeploymentConfig] = None,
+    user_config: DeploymentConfig | None = None,
 ) -> FullDeploymentConfig:
     """Generates a full deployment config from the user config.
 

--- a/aineko/core/node.py
+++ b/aineko/core/node.py
@@ -17,7 +17,7 @@ that users should override with their own implementation.
 import time
 import traceback
 from abc import ABC, abstractmethod
-from typing import Dict, Generator, List, Optional, Tuple
+from collections.abc import Generator
 
 import ray
 
@@ -83,16 +83,16 @@ class AbstractNode(ABC):
         self,
         node_name: str | None,
         pipeline_name: str,
-        poison_pill: Optional[ray.actor.ActorHandle] = None,
+        poison_pill: ray.actor.ActorHandle | None = None,
         test: bool = False,
     ) -> None:
         """Initialize the node."""
         self.name = node_name or self.__class__.__name__
         self.pipeline_name = pipeline_name
         self.last_heartbeat = time.time()
-        self.consumers: Dict = {}
-        self.producers: Dict = {}
-        self.params: Dict = {}
+        self.consumers: dict = {}
+        self.producers: dict = {}
+        self.params: dict = {}
         self.test = test
         self.log_levels = AINEKO_CONFIG.get("LOG_LEVELS")
         self.poison_pill = poison_pill
@@ -103,10 +103,10 @@ class AbstractNode(ABC):
 
     def setup_datasets(
         self,
-        datasets: Dict[str, dict],
-        inputs: Optional[List[str]] = None,
-        outputs: Optional[List[str]] = None,
-        prefix: Optional[str] = None,
+        datasets: dict[str, dict],
+        inputs: list[str] | None = None,
+        outputs: list[str] | None = None,
+        prefix: str | None = None,
         has_pipeline_prefix: bool = False,
     ) -> None:
         """Setup the consumer and producer for a node.
@@ -153,9 +153,9 @@ class AbstractNode(ABC):
 
     def setup_test(
         self,
-        inputs: Optional[dict] = None,
-        outputs: Optional[list] = None,
-        params: Optional[dict] = None,
+        inputs: dict | None = None,
+        outputs: list | None = None,
+        params: dict | None = None,
     ) -> None:
         """Setup the node for testing.
 
@@ -219,7 +219,7 @@ class AbstractNode(ABC):
         exc_info = traceback.format_exc()
         self.log(exc_info, level="debug")
 
-    def execute(self, params: Optional[dict] = None) -> None:
+    def execute(self, params: dict | None = None) -> None:
         """Execute the node.
 
         Wrapper for _execute method to be implemented by subclasses.
@@ -253,7 +253,7 @@ class AbstractNode(ABC):
             ray.get(self.poison_pill.activate.remote())
 
     @abstractmethod
-    def _execute(self, params: dict) -> Optional[bool]:
+    def _execute(self, params: dict) -> bool | None:
         """Execute the node.
 
         Args:
@@ -267,7 +267,7 @@ class AbstractNode(ABC):
         """
         raise NotImplementedError("_execute method not implemented")
 
-    def run_test(self, runtime: Optional[int] = None) -> dict:
+    def run_test(self, runtime: int | None = None) -> dict:
         """Execute the node in testing mode.
 
         Runs the steps in execute that involves the user defined methods.
@@ -310,8 +310,8 @@ class AbstractNode(ABC):
         }
 
     def run_test_yield(
-        self, runtime: Optional[int] = None
-    ) -> Generator[Tuple[dict, dict, "AbstractNode"], None, None]:
+        self, runtime: int | None = None
+    ) -> Generator[tuple[dict, dict, "AbstractNode"], None, None]:
         """Execute the node in testing mode, yielding at each iteration.
 
         This method is an alternative to `run_test`. Instead of returning the
@@ -375,7 +375,7 @@ class AbstractNode(ABC):
 
         self._post_loop_hook(self.params)
 
-    def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+    def _pre_loop_hook(self, params: dict | None = None) -> None:
         """Hook to be called before the node loop. User overrideable.
 
         Args:
@@ -386,7 +386,7 @@ class AbstractNode(ABC):
         """
         pass
 
-    def _post_loop_hook(self, params: Optional[dict] = None) -> None:
+    def _post_loop_hook(self, params: dict | None = None) -> None:
         """Hook to be called after the node loop. User overrideable.
 
         Args:

--- a/aineko/core/node_manager.py
+++ b/aineko/core/node_manager.py
@@ -6,9 +6,7 @@ The Node Manager is a special node that exists in every
 pipeline and is responsible for the following tasks:
  - Killing the ray instance when the poison pill is activated
 """
-
 import time
-from typing import Optional
 
 import ray
 
@@ -18,7 +16,7 @@ from aineko.core.node import AbstractNode
 class NodeManager(AbstractNode):
     """Manages all other nodes in pipeline."""
 
-    def _execute(self, params: Optional[dict] = None) -> None:
+    def _execute(self, params: dict | None = None) -> None:
         """Kills all other nodes."""
         # Sleep to prevent high CPU usage
         time.sleep(0.1)

--- a/aineko/core/runner.py
+++ b/aineko/core/runner.py
@@ -3,7 +3,6 @@
 """Submodule that handles the running of a pipeline from config."""
 import logging
 import time
-from typing import Optional
 
 import ray
 from confluent_kafka.admin import AdminClient, NewTopic  # type: ignore
@@ -41,10 +40,10 @@ class Runner:
     def __init__(
         self,
         pipeline_config_file: str,
-        pipeline_name: Optional[str] = None,
+        pipeline_name: str | None = None,
         kafka_config: dict = DEFAULT_KAFKA_CONFIG.get("BROKER_CONFIG"),
         metrics_export_port: int = AINEKO_CONFIG.get("RAY_METRICS_PORT"),
-        dataset_prefix: Optional[str] = None,
+        dataset_prefix: str | None = None,
     ):
         """Initializes the runner class."""
         self.pipeline_config_file = pipeline_config_file
@@ -110,7 +109,7 @@ class Runner:
         return config["pipeline"]
 
     def prepare_datasets(
-        self, config: dict, user_dataset_prefix: Optional[str] = None
+        self, config: dict, user_dataset_prefix: str | None = None
     ) -> bool:
         """Creates the required datasets for a given pipeline.
 

--- a/aineko/extras/fastapi/main.py
+++ b/aineko/extras/fastapi/main.py
@@ -12,9 +12,6 @@ and Producer objects are namespaced at the pipeline level. If you must
 have multiple FastAPI nodes, we recommend using different datasets to avoid
 namespace collisions.
 """
-
-from typing import Optional
-
 import uvicorn
 
 from aineko import AbstractNode, DatasetConsumer, DatasetProducer
@@ -114,7 +111,7 @@ class FastAPI(AbstractNode):
     ```
     """
 
-    def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+    def _pre_loop_hook(self, params: dict | None = None) -> None:
         """Initialize node state. Set env variables for Fast API app."""
         for key, value in self.consumers.items():
             consumers[key] = value

--- a/aineko/models/config_schema.py
+++ b/aineko/models/config_schema.py
@@ -1,8 +1,6 @@
 # Copyright 2023 Aineko Authors
 # SPDX-License-Identifier: Apache-2.0
 """Internal models for pipeline config validation."""
-from typing import Optional
-
 from pydantic import BaseModel, Field
 
 
@@ -16,19 +14,19 @@ class Config(BaseModel):
             """Dataset model."""
 
             type: str
-            params: Optional[dict] = None
+            params: dict | None = None
 
         class Node(BaseModel):
             """Node model."""
 
             class_name: str = Field(..., alias="class")
-            node_params: Optional[dict] = None
-            node_settings: Optional[dict] = None
-            inputs: Optional[list] = None
-            outputs: Optional[list] = None
+            node_params: dict | None = None
+            node_settings: dict | None = None
+            inputs: list | None = None
+            outputs: list | None = None
 
         name: str
-        default_node_settings: Optional[dict]
+        default_node_settings: dict | None
         nodes: dict[str, Node]
         datasets: dict[str, Dataset]
 

--- a/aineko/models/deploy_config_schema.py
+++ b/aineko/models/deploy_config_schema.py
@@ -12,9 +12,6 @@ explicitly injected into the config so all pipelines are explicitly defined.
 This config represents the source of truth for all deployments of aineko
 pipelines.
 """
-
-from typing import Dict, Optional
-
 from pydantic import BaseModel, field_validator
 
 from aineko.models.deploy_config_schema_internal import (
@@ -28,9 +25,9 @@ class DeploymentConfig(BaseModel, extra="forbid"):
     """User deployment configuration (Schema for deploy.yml)."""
 
     version: str
-    defaults: Optional[ParameterizableDefaults] = None
-    pipelines: Dict[str, GenericPipeline]
-    environments: Dict[str, Environment]
+    defaults: ParameterizableDefaults | None = None
+    pipelines: dict[str, GenericPipeline]
+    environments: dict[str, Environment]
 
     @field_validator("version")
     def semver(cls, v: str) -> str:  # pylint: disable=no-self-argument
@@ -44,7 +41,7 @@ class FullDeploymentConfig(BaseModel):
     """Full deployment configuration (Schema for deploy.yml)."""
 
     version: str
-    environments: Dict[str, Environment]
+    environments: dict[str, Environment]
 
     @field_validator("version")
     def semver(cls, v: str) -> str:  # pylint: disable=no-self-argument

--- a/aineko/models/deploy_config_schema_internal.py
+++ b/aineko/models/deploy_config_schema_internal.py
@@ -3,7 +3,6 @@
 """Internal models for deployment configuration."""
 
 import re
-from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, field_validator
 
@@ -31,17 +30,17 @@ class MachineConfig(BaseModel, extra="forbid"):
 class ParameterizableDefaults(BaseModel, extra="forbid"):
     """Parameters that can be set in the defaults block."""
 
-    machine_config: Optional[MachineConfig] = None
-    env_vars: Optional[Dict[str, str]] = None
+    machine_config: MachineConfig | None = None
+    env_vars: dict[str, str] | None = None
 
 
 class GenericPipeline(BaseModel, extra="forbid"):
     """Configuration for a pipeline defined under top-level pipelines key."""
 
     source: str
-    name: Optional[str] = None
-    machine_config: Optional[MachineConfig] = None
-    env_vars: Optional[Dict[str, str]] = None
+    name: str | None = None
+    machine_config: MachineConfig | None = None
+    env_vars: dict[str, str] | None = None
 
 
 class LoadBalancer(BaseModel, extra="forbid"):
@@ -54,31 +53,31 @@ class LoadBalancer(BaseModel, extra="forbid"):
 class SpecificPipeline(BaseModel, extra="forbid"):
     """Pipeline defined under the top-level environments key."""
 
-    source: Optional[str] = None  # Pipeline config file path
-    name: Optional[str] = None  # Pipeline name
-    machine_config: Optional[MachineConfig] = None
-    env_vars: Optional[Dict[str, str]] = None
+    source: str | None = None  # Pipeline config file path
+    name: str | None = None  # Pipeline name
+    machine_config: MachineConfig | None = None
+    env_vars: dict[str, str] | None = None
 
 
 class FullPipeline(BaseModel, extra="forbid"):
     """Pipeline defined in the full deployment config."""
 
     source: str
-    name: Optional[str] = None
+    name: str | None = None
     machine_config: MachineConfig
-    env_vars: Optional[Dict[str, str]] = None
+    env_vars: dict[str, str] | None = None
 
 
 class Environment(BaseModel, extra="forbid"):
     """Environment defined under the top-level environments key."""
 
-    pipelines: List[Union[str, Dict[str, SpecificPipeline]]]
-    load_balancers: Optional[Dict[str, List[LoadBalancer]]] = None
+    pipelines: list[str | dict[str, SpecificPipeline]]
+    load_balancers: dict[str, list[LoadBalancer]] | None = None
 
     @field_validator("load_balancers")
     def validate_lb_endpoint(  # pylint: disable=no-self-argument
-        cls, value: Optional[Dict[str, List[LoadBalancer]]]
-    ) -> None | Dict[str, List[LoadBalancer]]:
+        cls, value: dict[str, list[LoadBalancer]] | None
+    ) -> None | dict[str, list[LoadBalancer]]:
         """Validates Load balancer endpoints.
 
         The following criteria apply:
@@ -103,5 +102,5 @@ class Environment(BaseModel, extra="forbid"):
 class FullEnvironment(BaseModel, extra="forbid"):
     """Environment defined under the top-level environments key."""
 
-    pipelines: List[Union[Dict[str, FullPipeline], str]]
-    load_balancers: Optional[Dict[str, List[LoadBalancer]]] = None
+    pipelines: list[dict[str, FullPipeline] | str]
+    load_balancers: dict[str, list[LoadBalancer]] | None = None

--- a/aineko/models/project_config_schema.py
+++ b/aineko/models/project_config_schema.py
@@ -5,9 +5,6 @@
 These models are used to validate the project configuration specified in
 repos that are used in `aineko create`.
 """
-
-from typing import Optional
-
 from pydantic import BaseModel, field_validator
 
 from aineko import __version__
@@ -18,9 +15,9 @@ class ProjectConfig(BaseModel):
 
     aineko_version: str
     project_name: str
-    project_slug: Optional[str] = None
-    project_description: Optional[str] = None
-    pipeline_slug: Optional[str] = None
+    project_slug: str | None = None
+    project_description: str | None = None
+    pipeline_slug: str | None = None
 
     @field_validator("aineko_version")
     def version(cls, v: str) -> str:  # pylint: disable=no-self-argument

--- a/aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/nodes.py
+++ b/aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/nodes.py
@@ -3,7 +3,6 @@
 """Example file showing how to create nodes."""
 
 import time
-from typing import Optional
 
 from aineko.core.node import AbstractNode
 
@@ -11,11 +10,11 @@ from aineko.core.node import AbstractNode
 class MySequencerNode(AbstractNode):
     """Example node."""
 
-    def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+    def _pre_loop_hook(self, params: dict | None = None) -> None:
         """Optional; used to initialize node state."""
         self.current_val = params.get("initial_state", 0)
 
-    def _execute(self, params: Optional[dict] = None) -> Optional[bool]:
+    def _execute(self, params: dict | None = None) -> bool | None:
         """Required; function repeatedly executes.
 
         Accesses inputs via `self.consumer`, and outputs via
@@ -30,7 +29,7 @@ class MySequencerNode(AbstractNode):
 class PrintInput(AbstractNode):
     """Prints input."""
 
-    def _execute(self, params: Optional[dict] = None):
+    def _execute(self, params: dict | None = None):
         for dataset, consumer in self.consumers.items():
             msg = consumer.consume(how="next")
             if msg is None:
@@ -43,11 +42,11 @@ class PrintInput(AbstractNode):
 class MySumNode(AbstractNode):
     """Example node."""
 
-    def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+    def _pre_loop_hook(self, params: dict | None = None) -> None:
         """Optional; used to initialize node state."""
         self.state = params.get("initial_state", 0)
 
-    def _execute(self, params: Optional[dict] = None) -> Optional[bool]:
+    def _execute(self, params: dict | None = None) -> bool | None:
         """Required; function repeatedly executes.
 
         Accesses inputs via `self.consumer`, and outputs via

--- a/aineko/utils/imports.py
+++ b/aineko/utils/imports.py
@@ -3,14 +3,14 @@
 """Import utilities."""
 import importlib
 import inspect
-from typing import Any, Optional
+from typing import Any
 
 
 def import_from_string(  # type: ignore[no-untyped-def]
     attr: str,
     kind: str,
-    reqd_params: Optional[list] = None,
-    ret_type: Optional[Any] = None,
+    reqd_params: list | None = None,
+    ret_type: Any | None = None,
 ):
     """Get a function from a string.
 

--- a/aineko/utils/io.py
+++ b/aineko/utils/io.py
@@ -1,8 +1,6 @@
 # Copyright 2023 Aineko Authors
 # SPDX-License-Identifier: Apache-2.0
 """IO utilities."""
-from typing import Union
-
 import yaml
 
 
@@ -15,14 +13,14 @@ def load_yaml(file_path: str) -> dict:
     Returns:
         dictionary of yaml file
     """
-    with open(file_path, "r", encoding="utf-8") as conf_file:
+    with open(file_path, encoding="utf-8") as conf_file:
         contents = yaml.safe_load(conf_file)
     if not contents:
         raise ValueError(f"YAML file {file_path} cannot be loaded.")
     return contents
 
 
-def load_yamls(file_paths: Union[str, list]) -> dict:
+def load_yamls(file_paths: str | list) -> dict:
     """Load yaml file(s) into a dictionary.
 
     If multiple keys with the same name exist, the last one will be used.

--- a/docs/developer_guide/aineko_project.md
+++ b/docs/developer_guide/aineko_project.md
@@ -50,7 +50,7 @@ A node requires:
 **`_execute`** is the main logic that run recurrently. As of writing, user should explicitly produce and consume within this method like so:
 
 ```python
-def _execute(self, params: Optional[dict] = None):
+def _execute(self, params: dict | None = None):
     """This node takes an input number and increments it by 1."""
     input_number = self.consumers["my_input_dataset"].next()
     # if we want the most recent message, we can use .last()

--- a/docs/examples/aineko_dream.md
+++ b/docs/examples/aineko_dream.md
@@ -122,6 +122,7 @@ Here we add 2 evaluation steps and an evaluation model:
 Here is the pipeline configuration used to generate this example. We could even configure and run three separate pipelines that use different models and expose different endpoints for each of them.
 
 ??? abstract "Pipeline configuration"
+
     ```yaml
     pipeline:
       name: gpt3-template-generator
@@ -212,7 +213,7 @@ The `SecurityEvaluation` node takes the LLM response and creates a temporary fil
         class GitHubDocFetcher(AbstractNode):
             """Node that fetches code documents from GitHub."""
 
-            def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+            def _pre_loop_hook(self, params: dict | None = None) -> None:
                 """Initialize connection with GitHub and fetch latest document."""
                 # Set parameters
                 self.access_token = os.environ.get("GITHUB_ACCESS_TOKEN")
@@ -228,7 +229,7 @@ The `SecurityEvaluation` node takes the LLM response and creates a temporary fil
                 # Fetch current document
                 self.emit_new_document()
 
-            def _execute(self, params: Optional[dict] = None) -> Optional[bool]:
+            def _execute(self, params: dict | None = None) -> bool | None:
                 """Update document in response to commit events."""
                 # Check for new commit events from GitHub
                 message = self.consumers["github_event"].consume()
@@ -256,14 +257,14 @@ The `SecurityEvaluation` node takes the LLM response and creates a temporary fil
         class OpenAIClient(AbstractNode):
             """Node that queries OpenAI LLMs."""
 
-            def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+            def _pre_loop_hook(self, params: dict | None = None) -> None:
                 """Initialize connection with OpenAI."""
                 self.model = params.get("model")
                 self.max_tokens = params.get("max_tokens")
                 self.temperature = params.get("temperature")
                 openai.api_key = os.getenv("OPENAI_API_KEY")
 
-            def _execute(self, params: Optional[dict] = None) -> Optional[bool]:
+            def _execute(self, params: dict | None = None) -> bool | None:
                 """Query OpenAI LLM."""
                 message = self.consumers["generated_prompt"].consume()
                 if message is None:
@@ -290,12 +291,12 @@ The `SecurityEvaluation` node takes the LLM response and creates a temporary fil
         ```
 
     === "`SecurityEvaluation`"
-    
+
         ```python
         class SecurityEvaluation(AbstractNode):
             """Node that evaluates security of code."""
 
-            def _execute(self, params: Optional[dict] = None) -> None:
+            def _execute(self, params: dict | None = None) -> None:
                 """Evaluate Python code."""
                 message = self.consumers["llm_response"].consume()
                 if message is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@
 import datetime
 import os
 import time
-from typing import Optional
 
 import pytest
 from click.testing import CliRunner
@@ -72,7 +71,7 @@ def dummy_node():
     class DummyNode(AbstractNode):
         """Dummy node that passes through messages."""
 
-        def _execute(self, params: Optional[dict] = None) -> Optional[bool]:
+        def _execute(self, params: dict | None = None) -> bool | None:
             """Consumes message from input and outputs it to output."""
             msg = self.consumers["input"].consume(how="next", timeout=0)
             self.producers["output"].produce(msg)
@@ -99,13 +98,13 @@ def test_sequencer_node():
     class TestSequencer(AbstractNode):
         """Test sequencer node."""
 
-        def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+        def _pre_loop_hook(self, params: dict | None = None) -> None:
             """Pre loop hook."""
             self.cur_integer = int(params.get("start_int", 0))
             self.num_messages = 0
             self.log(f"Starting at {self.cur_integer}", level="info")
 
-        def _execute(self, params: Optional[dict] = None) -> None:
+        def _execute(self, params: dict | None = None) -> None:
             """Generates a sequence of integers and writes them to a dataset.
 
             Args:
@@ -135,7 +134,7 @@ def test_doubler_node():
     class TestDoubler(AbstractNode):
         """Test doubler node."""
 
-        def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+        def _pre_loop_hook(self, params: dict | None = None) -> None:
             """Initializes node with current time.
 
             Args:
@@ -144,7 +143,7 @@ def test_doubler_node():
             self.cur_time = time.time()
             self.cur_integer = 0
 
-        def _execute(self, params: Optional[dict] = None) -> None:
+        def _execute(self, params: dict | None = None) -> None:
             """Generates a sequence of integers and writes them to a dataset.
 
             Args:
@@ -190,12 +189,12 @@ def test_internal_value_setter_node():
     class TestInternalValueSetter(AbstractNode):
         """Test sequencer node."""
 
-        def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+        def _pre_loop_hook(self, params: dict | None = None) -> None:
             """Pre loop hook."""
             self.cur_integer = 0
             self.num_messages = 0
 
-        def _execute(self, params: Optional[dict] = None) -> None:
+        def _execute(self, params: dict | None = None) -> None:
             """Consumes message from input and sets content to internal value."""
 
             # Read message from consumer

--- a/tests/core/test_node.py
+++ b/tests/core/test_node.py
@@ -23,7 +23,7 @@ def test_node_setup_and_run_test(dummy_node) -> None:
     run_time = time.time() - start_time
 
     # Check that correct keys exist
-    assert set(output.keys()) == set(["logging", "output"])
+    assert set(output.keys()) == {"logging", "output"}
     # Check that correct messages are received
     assert [i["message"] for i in output["output"] if i] == [1, 2, 3]
     # Check that timeout worked as intended

--- a/tests/integration/test_kafka_edge_cases.py
+++ b/tests/integration/test_kafka_edge_cases.py
@@ -1,9 +1,7 @@
 # Copyright 2023 Aineko Authors
 # SPDX-License-Identifier: Apache-2.0
 """Tests edge cases to do with kafka clusters."""
-
 import time
-from typing import Optional
 
 import pytest
 import ray
@@ -14,7 +12,7 @@ from aineko import AbstractNode, DatasetConsumer, Runner
 class ConsumerNode(AbstractNode):
     """Node that consumes message using different consume methods."""
 
-    def _execute(self, params: Optional[dict] = None) -> None:
+    def _execute(self, params: dict | None = None) -> None:
         """Consumes message."""
         self.consumers["messages"].consume(how="next")
         self.consumers["messages"].consume(how="last", timeout=1)

--- a/tests/integration/test_runner_with_kafka.py
+++ b/tests/integration/test_runner_with_kafka.py
@@ -4,7 +4,6 @@
 with a kafka zookeeper and broker service available.
 """
 import time
-from typing import Optional
 
 import pytest
 import ray
@@ -25,10 +24,10 @@ MESSAGES = [
 class MessageWriter(AbstractNode):
     """Node that produces messages every 0.1 second."""
 
-    def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+    def _pre_loop_hook(self, params: dict | None = None) -> None:
         self.messages = MESSAGES
 
-    def _execute(self, params: Optional[dict] = None) -> None:
+    def _execute(self, params: dict | None = None) -> None:
         """Sends message."""
         if len(self.messages) > 0:
             self.producers["messages"].produce(self.messages.pop(0))
@@ -37,7 +36,7 @@ class MessageWriter(AbstractNode):
             self.producers["messages"].produce("END")
             return False
 
-    def _post_loop_hook(self, params: Optional[dict] = None) -> None:
+    def _post_loop_hook(self, params: dict | None = None) -> None:
         """Activate the poison pill upon execute completion."""
         time.sleep(1)
         self.activate_poison_pill()
@@ -46,13 +45,13 @@ class MessageWriter(AbstractNode):
 class MessageReader(AbstractNode):
     """Node that reads messages and logs them."""
 
-    def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+    def _pre_loop_hook(self, params: dict | None = None) -> None:
         self.messages = MESSAGES
         self.received = []
         self.timeout = 20  # seconds to wait for before terminating
         self.last_updated = time.time()
 
-    def _execute(self, params: Optional[dict] = None) -> None:
+    def _execute(self, params: dict | None = None) -> None:
         """Read message"""
         msg = self.consumers["messages"].next()
         if time.time() - self.last_updated > self.timeout:
@@ -69,7 +68,7 @@ class MessageReader(AbstractNode):
         self.received.append(msg["message"])
         self.last_updated = time.time()
 
-    def _post_loop_hook(self, params: Optional[dict] = None) -> None:
+    def _post_loop_hook(self, params: dict | None = None) -> None:
         if self.messages != self.received:
             raise ValueError(
                 "Failed to read expected messages."


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
Python 3.10 allows for simplified type hints and some type hints were using the older notation.
Example:
`Optional[str]` can be written as `str|None`.

## Motivation
<!-- Describe the motivation for this change. -->
Keeping the type hints consistent across all files.


## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
