### PR TITLE
feat: implement log_to_dataset to read python native logs and produce them to the logging dataset - BLD-1212

### DIFF
--- a/aineko/core/node.py
+++ b/aineko/core/node.py
@@ -87,7 +87,7 @@ class AbstractNode(ABC):
         poison_pill: Optional[ray.actor.ActorHandle] = None,
         test: bool = False,
         logging_namespace: Optional[str] = None,
-        log_to_dataset: bool = False,
+        log_to_dataset: Optional[bool] = None,
     ) -> None:
         """Initialize the node."""
         self.name = node_name or self.__class__.__name__

--- a/aineko/core/node.py
+++ b/aineko/core/node.py
@@ -14,6 +14,7 @@ The AbstractNode class is the parent class for all Aineko pipeline nodes.
 It contains  helper methods for setup, util methods, and dummy methods
 that users should override with their own implementation.
 """
+import logging
 import time
 import traceback
 from abc import ABC, abstractmethod
@@ -85,6 +86,8 @@ class AbstractNode(ABC):
         pipeline_name: str,
         poison_pill: Optional[ray.actor.ActorHandle] = None,
         test: bool = False,
+        logging_namespace: Optional[str] = None,
+        log_to_dataset: bool = False,
     ) -> None:
         """Initialize the node."""
         self.name = node_name or self.__class__.__name__
@@ -96,6 +99,35 @@ class AbstractNode(ABC):
         self.test = test
         self.log_levels = AINEKO_CONFIG.get("LOG_LEVELS")
         self.poison_pill = poison_pill
+
+        if log_to_dataset:
+            node_log_levels = self.log_levels
+            node_logger = self.log
+            internal_logger = logging.getLogger(logging_namespace)
+            internal_logger.setLevel(logging.DEBUG)
+
+            class LogHandler(logging.Handler):
+                """Custom log handler for the node."""
+
+                def emit(self, record: logging.LogRecord) -> None:
+                    """Emit a log record to node's log method.
+
+                    Args:
+                        record: Log record to emit.
+                    """
+                    level_name = record.levelname.lower()
+                    if level_name in node_log_levels:
+                        node_logger(self.format(record), level=level_name)
+                    else:
+                        node_logger(self.format(record), level="info")
+
+            # Create and configure the handler
+            handler = LogHandler()
+            formatter = logging.Formatter(
+                "%(asctime)s - %(name)s - %(message)s"
+            )
+            handler.setFormatter(formatter)
+            internal_logger.addHandler(handler)
 
     def enable_test_mode(self) -> None:
         """Enable test mode."""

--- a/aineko/models/config_schema.py
+++ b/aineko/models/config_schema.py
@@ -26,10 +26,14 @@ class Config(BaseModel):
             node_settings: Optional[dict] = None
             inputs: Optional[list] = None
             outputs: Optional[list] = None
+            log_to_dataset: bool = False
+            logging_namespace: Optional[str] = None
 
         name: str
         default_node_settings: Optional[dict]
         nodes: dict[str, Node]
         datasets: dict[str, Dataset]
+        log_to_dataset: bool = False
+        logging_namespace: Optional[str] = None
 
     pipeline: Pipeline

--- a/aineko/models/config_schema.py
+++ b/aineko/models/config_schema.py
@@ -3,7 +3,7 @@
 """Internal models for pipeline config validation."""
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class Config(BaseModel):
@@ -26,14 +26,49 @@ class Config(BaseModel):
             node_settings: Optional[dict] = None
             inputs: Optional[list] = None
             outputs: Optional[list] = None
-            log_to_dataset: bool = False
+            log_to_dataset: Optional[bool] = None
             logging_namespace: Optional[str] = None
 
         name: str
         default_node_settings: Optional[dict]
         nodes: dict[str, Node]
         datasets: dict[str, Dataset]
-        log_to_dataset: bool = False
+        log_to_dataset: Optional[bool] = None
         logging_namespace: Optional[str] = None
 
     pipeline: Pipeline
+
+    @model_validator(mode="after")
+    def validate_logging_parameters(self) -> "Config":
+        """Validate logging parameters.
+
+        This method validates the logging parameters on the pipeline level and
+        the node level. It also sets the default values for the logging
+        parameters on the node level if they are not specified.
+        """
+        if not self.pipeline.log_to_dataset and self.pipeline.logging_namespace:
+            raise ValueError(
+                "logging_namespace must not be specified if log_to_dataset is"
+                " falsy."
+            )
+        for node in self.pipeline.nodes.values():
+            if not node.log_to_dataset and node.logging_namespace:
+                raise ValueError(
+                    "logging_namespace must not be specified if log_to_dataset"
+                    " is falsy."
+                )
+
+        if self.pipeline.log_to_dataset is True:
+            for node in self.pipeline.nodes.values():
+                if node.log_to_dataset is None:
+                    node.log_to_dataset = True
+            if self.pipeline.logging_namespace is not None:
+                for node in self.pipeline.nodes.values():
+                    if node.logging_namespace is None:
+                        node.logging_namespace = self.pipeline.logging_namespace
+
+        elif self.pipeline.log_to_dataset is False:
+            for node in self.pipeline.nodes.values():
+                if node.log_to_dataset is None:
+                    node.log_to_dataset = False
+        return self

--- a/docs/.styles/Vocab/Aineko/accept.txt
+++ b/docs/.styles/Vocab/Aineko/accept.txt
@@ -16,3 +16,4 @@ CLI
 [Bb]lockchain
 GitHub
 github
+namespace

--- a/docs/developer_guide/node_implementation.md
+++ b/docs/developer_guide/node_implementation.md
@@ -222,6 +222,7 @@ Since `self.log` is inherited from `AbstractNode`, you can't use it outside of a
         log_to_dataset: true
         logging_namespace: foo
         ```
+    * Logging parameters at the node level have precedence over logging parameters at the pipeline level. For example, if `log_to_dataset` is set to `true` at the pipeline level, but `log_to_dataset` is set to `false` for node `xyz`, then node `xyz` will nog read and produce log entries. However, all other nodes will read and produce log entries.
 
 
 ### PoisonPill

--- a/tests/conf/invalid_node_log_to_dataset.yml
+++ b/tests/conf/invalid_node_log_to_dataset.yml
@@ -1,0 +1,20 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+pipeline:
+  name: test_log_to_dataset
+
+  default_node_settings:
+    num_cpus: 0.5
+
+  nodes:
+    with_logging:
+      class: foo.bar.BazNode
+      log_to_dataset: true
+      logging_namespace: "okenia"
+
+    without_logging:
+      class: foo.bar.BazNode
+      log_to_dataset: false
+      logging_namespace: "okenia"
+
+  datasets: {}

--- a/tests/conf/invalid_pipeline_log_to_dataset.yml
+++ b/tests/conf/invalid_pipeline_log_to_dataset.yml
@@ -1,0 +1,21 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+pipeline:
+  name: test_log_to_dataset
+
+  default_node_settings:
+    num_cpus: 0.5
+
+  nodes:
+    nothing_specified:
+      class: foo.bar.BazNode
+
+    logging_enabled:
+      class: foo.bar.BazNode
+      log_to_dataset: true
+      logging_namespace: "okenia"
+
+  log_to_dataset: false
+  logging_namespace: "okenia"
+
+  datasets: {}

--- a/tests/conf/node_log_to_dataset.yml
+++ b/tests/conf/node_log_to_dataset.yml
@@ -1,0 +1,18 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+pipeline:
+  name: test_log_to_dataset
+
+  default_node_settings:
+    num_cpus: 0.5
+
+  nodes:
+    with_logging:
+      class: foo.bar.BazNode
+      log_to_dataset: true
+      logging_namespace: "okenia"
+
+    without_logging:
+      class: foo.bar.BazNode
+
+  datasets: {}

--- a/tests/conf/pipeline_dont_log_to_dataset.yml
+++ b/tests/conf/pipeline_dont_log_to_dataset.yml
@@ -1,0 +1,20 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+pipeline:
+  name: test_log_to_dataset
+
+  default_node_settings:
+    num_cpus: 0.5
+
+  nodes:
+    nothing_specified:
+      class: foo.bar.BazNode
+
+    logging_enabled:
+      class: foo.bar.BazNode
+      log_to_dataset: true
+      logging_namespace: "okenia"
+
+  log_to_dataset: false
+
+  datasets: {}

--- a/tests/conf/pipeline_log_to_dataset.yml
+++ b/tests/conf/pipeline_log_to_dataset.yml
@@ -1,0 +1,20 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+pipeline:
+  name: test_log_to_dataset
+
+  default_node_settings:
+    num_cpus: 0.5
+
+  nodes:
+    nothing_specified:
+      class: foo.bar.BazNode
+
+    no_logging:
+      class: foo.bar.BazNode
+      log_to_dataset: false
+
+  log_to_dataset: true
+  logging_namespace: "okenia"
+
+  datasets: {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,3 +211,56 @@ def test_internal_value_setter_node():
             self.cur_integer = cur_integer
 
     return TestInternalValueSetter
+
+
+@pytest.fixture(scope="module")
+def test_log_internals(request):
+    """Returns a node that produces messages and calls an external function.
+
+    The node is expected to call the external function which has a logger that
+    logs a message with info level. As part of the AbstractNode, the node
+    should capture external logs and produce them to the logging dataset.
+
+    Returns:
+        A tuple of the node and the number of messages produced.
+    """
+    import logging
+
+    if request:
+        namespace = request.param
+    else:
+        namespace = None
+
+    def dummy_function():
+        """Dummy function which logs a message with info level."""
+        logger = logging.getLogger(namespace)
+        logger.info("Dummy function called.")
+
+    """Returns a node that logs internal values."""
+    MESSAGES = [
+        0,
+        1,
+        2,
+        3,
+        "test_1",
+        "test_2",
+        {"test_1": 1, "test_2": 2},
+    ]
+
+    class MessageWriter(AbstractNode):
+        """Node that produces messages every 0.1 second."""
+
+        def _pre_loop_hook(self, params: Optional[dict] = None) -> None:
+            self.messages = MESSAGES.copy()
+
+        def _execute(self, params: Optional[dict] = None) -> None:
+            """Sends message."""
+            if len(self.messages) > 0:
+                dummy_function()
+                self.producers["messages"].produce(self.messages.pop(0))
+                time.sleep(0.1)
+            else:
+                self.producers["messages"].produce("END")
+                return False
+
+    return (MessageWriter, len(MESSAGES))

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+from aineko.utils.io import load_yaml
+
 
 @pytest.fixture(scope="function")
 def machine_config():
@@ -44,3 +46,28 @@ def load_balancer_config():
 @pytest.fixture(scope="function")
 def load_balancers_config(load_balancer_config):
     return {"load_balancers": {"test-point": [load_balancer_config]}}
+
+
+@pytest.fixture(scope="function")
+def node_log_to_dataset():
+    return load_yaml("tests/conf/node_log_to_dataset.yml")
+
+
+@pytest.fixture(scope="function")
+def pipeline_log_to_dataset():
+    return load_yaml("tests/conf/pipeline_log_to_dataset.yml")
+
+
+@pytest.fixture(scope="function")
+def pipeline_dont_log_to_dataset():
+    return load_yaml("tests/conf/pipeline_dont_log_to_dataset.yml")
+
+
+@pytest.fixture(scope="function")
+def invalid_pipeline_log_to_dataset():
+    return load_yaml("tests/conf/invalid_pipeline_log_to_dataset.yml")
+
+
+@pytest.fixture(scope="function")
+def invalid_node_log_to_dataset():
+    return load_yaml("tests/conf/invalid_node_log_to_dataset.yml")

--- a/tests/models/test_log_to_dataset.py
+++ b/tests/models/test_log_to_dataset.py
@@ -1,0 +1,102 @@
+# Copyright 2023 Aineko Authors
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from pydantic import ValidationError
+
+from aineko.models.config_schema import Config
+
+
+def test_node_log_to_dataset(node_log_to_dataset, subtests):
+    """Test node log_to_dataset."""
+    with subtests.test("Test if the yml config is valid"):
+        assert Config(**node_log_to_dataset)
+
+    validated_config = Config(**node_log_to_dataset)
+
+    with subtests.test(
+        "Test if the nodes have the expected logging parmameters"
+    ):
+        assert (
+            validated_config.pipeline.nodes["with_logging"].log_to_dataset
+            is True
+        )
+        assert (
+            validated_config.pipeline.nodes["without_logging"].log_to_dataset
+            is None
+        )
+        assert (
+            validated_config.pipeline.nodes["with_logging"].logging_namespace
+            == "okenia"
+        )
+
+
+def test_pipeline_log_to_dataset(pipeline_log_to_dataset, subtests):
+    """Test pipeline log_to_dataset."""
+    with subtests.test("Test if the yml config is valid"):
+        assert Config(**pipeline_log_to_dataset)
+
+    validated_config = Config(**pipeline_log_to_dataset)
+
+    with subtests.test(
+        "Test if the nodes have the expected logging parmameters"
+    ):
+        assert (
+            validated_config.pipeline.nodes["nothing_specified"].log_to_dataset
+            is True
+        )
+        assert (
+            validated_config.pipeline.nodes["no_logging"].log_to_dataset
+            is False
+        )
+        assert (
+            validated_config.pipeline.nodes[
+                "nothing_specified"
+            ].logging_namespace
+            == "okenia"
+        )
+        assert (
+            validated_config.pipeline.nodes["no_logging"].logging_namespace
+            == "okenia"
+        )
+
+
+def test_pipeline_dont_log_to_dataset(pipeline_dont_log_to_dataset, subtests):
+    """Test pipeline log_to_dataset."""
+    with subtests.test("Test if the yml config is valid"):
+        assert Config(**pipeline_dont_log_to_dataset)
+
+    validated_config = Config(**pipeline_dont_log_to_dataset)
+
+    with subtests.test(
+        "Test if the nodes have the expected logging parmameters"
+    ):
+        assert (
+            validated_config.pipeline.nodes["nothing_specified"].log_to_dataset
+            is False
+        )
+        assert (
+            validated_config.pipeline.nodes["logging_enabled"].log_to_dataset
+            is True
+        )
+        assert (
+            validated_config.pipeline.nodes[
+                "nothing_specified"
+            ].logging_namespace
+            is None
+        )
+        assert (
+            validated_config.pipeline.nodes["logging_enabled"].logging_namespace
+            == "okenia"
+        )
+
+
+def test_invalid_pipeline_log_to_dataset(invalid_pipeline_log_to_dataset):
+    """Test invalid pipeline log_to_dataset."""
+    with pytest.raises(ValidationError):
+        Config(**invalid_pipeline_log_to_dataset)
+
+
+def test_invalid_node_log_to_dataset(invalid_node_log_to_dataset):
+    """Test invalid pipeline log_to_dataset."""
+    with pytest.raises(ValidationError):
+        Config(**invalid_node_log_to_dataset)


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
This PR implements a new feature to read logs that are produced outside of a node using the native python logging module.


## Motivation
<!-- Describe the motivation for this change. -->
Catching logs from outside of the nodes can be very useful for debugging or monitoring.

## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
