### PR TITLE
fix: capture the last consumed value before processing it

### DIFF
--- a/aineko/core/node.py
+++ b/aineko/core/node.py
@@ -344,6 +344,12 @@ class AbstractNode(ABC):
             last_produced_values = {}
             last_consumed_values = {}
 
+            # Capture last consumed values
+            for dataset_name, consumer in self.consumers.items():
+                if consumer.values:
+                    last_value = consumer.values[0]
+                    last_consumed_values[dataset_name] = last_value
+
             run_loop = self._execute(self.params)  # type: ignore
 
             # Do not end loop if runtime not exceeded
@@ -356,12 +362,6 @@ class AbstractNode(ABC):
                 consumer.empty for consumer in self.consumers.values()
             ):
                 run_loop = False
-
-            # Capture last consumed values
-            for dataset_name, consumer in self.consumers.items():
-                if consumer.values:
-                    last_value = consumer.values[0]
-                    last_consumed_values[dataset_name] = last_value
 
             # Capture last produced values
             for dataset_name, producer in self.producers.items():

--- a/tests/core/test_node.py
+++ b/tests/core/test_node.py
@@ -100,4 +100,4 @@ def test_output_yielding_no_output(test_internal_value_setter_node):
     node.setup_test(inputs={"integer_sequence": input_sequence}, outputs=[])
     for input, _, node_instance in node.run_test_yield():
         if input.get("integer_sequence"):
-            assert input["integer_sequence"] == node_instance.cur_integer + 1
+            assert input["integer_sequence"] == node_instance.cur_integer


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
This PR fixes the `run_test_yield` method to properly yield the last consumed value.

Please ignore the failing "lint docs" job.

## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
