### PR TITLE
refactor: config loader to return a python object of the Config instead of a dict

### DIFF
--- a/aineko/core/config_loader.py
+++ b/aineko/core/config_loader.py
@@ -39,32 +39,32 @@ class ConfigLoader:
             "DEFAULT_PIPELINE_CONFIG"
         )
 
-    def load_config(self) -> dict:
+    def load_config(self) -> Config:
         """Load and validate the pipeline config.
 
         Raises:
             ValidationError: If the config does not match the schema
 
         Returns:
-            The pipeline config as a dictionary
+            The validated pipeline config as a Pydantic Config object
         """
-        config = load_yaml(self.pipeline_config_file)
+        raw_config = load_yaml(self.pipeline_config_file)
 
         try:
-            Config(**config)
+            config = Config(**raw_config)
         except ValidationError as e:
             logger.error(
                 "Schema validation failed for pipeline `%s` loaded from %s. "
                 "See detailed error below.",
-                config["pipeline"]["name"],
+                raw_config["pipeline"]["name"],
                 self.pipeline_config_file,
             )
             raise e
 
         # Inject environment variables into node params
-        for node in config["pipeline"]["nodes"].values():
-            if "node_params" in node and node["node_params"] is not None:
-                node["node_params"] = self.inject_env_vars(node["node_params"])
+        for node in config.pipeline.nodes.values():
+            if node.node_params is not None:
+                node.node_params = self.inject_env_vars(node.node_params)
 
         return config
 

--- a/aineko/core/config_loader.py
+++ b/aineko/core/config_loader.py
@@ -24,7 +24,6 @@ class ConfigLoader:
 
     Attributes:
         pipeline_config_file (str): path to the pipeline configuration file
-        config_schema (Config): Pydantic model to validate a pipeline config
 
     Methods:
         load_config: loads and validates the pipeline config from a yaml file
@@ -39,9 +38,6 @@ class ConfigLoader:
         self.pipeline_config_file = pipeline_config_file or AINEKO_CONFIG.get(
             "DEFAULT_PIPELINE_CONFIG"
         )
-
-        # Setup config schema
-        self.config_schema = Config
 
     def load_config(self) -> dict:
         """Load and validate the pipeline config.

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -88,16 +88,22 @@ class DatasetConsumer:
         self.has_pipeline_prefix = has_pipeline_prefix
         self.cached = False
 
-        if isinstance(dataset_config, Dataset):
-            dataset_config = dataset_config.model_dump()
+        if isinstance(dataset_config, dict):
+            if "type" not in dataset_config:
+                dataset_config["type"] = "kafka_stream"
+
+            dataset_config = Dataset(**dataset_config)
 
         consumer_config = self.kafka_config.get("CONSUMER_CONFIG")
         # Overwrite bootstrap server with broker if provided
         if bootstrap_servers:
             consumer_config["bootstrap.servers"] = bootstrap_servers
 
+        if dataset_config.params is None:
+            dataset_config.params = {}
+
         # Override default config with dataset specific config
-        for param, value in dataset_config.get("params", {}).items():
+        for param, value in dataset_config.params.items():
             consumer_config[param] = value
 
         topic_name = dataset_name

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -32,6 +32,7 @@ from confluent_kafka import (  # type: ignore
 
 from aineko.config import DEFAULT_KAFKA_CONFIG
 from aineko.models.base import MessageData
+from aineko.models.config_schema import Dataset
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +76,7 @@ class DatasetConsumer:
         dataset_name: str,
         node_name: str,
         pipeline_name: str,
-        dataset_config: Dict[str, Any],
+        dataset_config: Union[Dict[str, Any], Dataset],
         bootstrap_servers: Optional[str] = None,
         prefix: Optional[str] = None,
         has_pipeline_prefix: bool = False,
@@ -86,6 +87,9 @@ class DatasetConsumer:
         self.prefix = prefix
         self.has_pipeline_prefix = has_pipeline_prefix
         self.cached = False
+
+        if isinstance(dataset_config, Dataset):
+            dataset_config = dataset_config.model_dump()
 
         consumer_config = self.kafka_config.get("CONSUMER_CONFIG")
         # Overwrite bootstrap server with broker if provided

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -30,7 +30,7 @@ from confluent_kafka import (  # type: ignore
     Producer,
 )
 
-from aineko.config import DEFAULT_KAFKA_CONFIG
+from aineko.config import AINEKO_CONFIG, DEFAULT_KAFKA_CONFIG
 from aineko.models.base import MessageData
 from aineko.models.config_schema import Dataset
 
@@ -90,7 +90,7 @@ class DatasetConsumer:
 
         if isinstance(dataset_config, dict):
             if "type" not in dataset_config:
-                dataset_config["type"] = "kafka_stream"
+                dataset_config["type"] = AINEKO_CONFIG.get("KAFKA_STREAM_TYPE")
 
             dataset_config = Dataset(**dataset_config)
 

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -359,7 +359,7 @@ class DatasetProducer:
         dataset_name: str,
         node_name: str,
         pipeline_name: str,
-        dataset_config: Dict[str, Any],
+        dataset_config: Union[Dict, Dataset],
         prefix: Optional[str] = None,
         has_pipeline_prefix: bool = False,
     ):
@@ -384,11 +384,14 @@ class DatasetProducer:
         # Set producer parameters
         producer_config = self.kafka_config.get("PRODUCER_CONFIG")
 
+        if isinstance(dataset_config, dict):
+            dataset_config = Dataset(**dataset_config)
+
         # Override default config with dataset specific config
-        if "params" in dataset_config:
+        if dataset_config.params:
             for param in self.kafka_config.get("PRODUCER_OVERRIDABLES"):
-                if param in dataset_config["params"]:
-                    producer_config[param] = dataset_config["params"][param]
+                if param in dataset_config.params:
+                    producer_config[param] = dataset_config.params[param]
 
         # Create producer
         self.producer = Producer(producer_config)

--- a/aineko/core/node.py
+++ b/aineko/core/node.py
@@ -32,6 +32,7 @@ from aineko.core.dataset import (
     FakeDatasetConsumer,
     FakeDatasetProducer,
 )
+from aineko.models.config_schema import Dataset
 
 
 class PoisonPill:
@@ -103,7 +104,7 @@ class AbstractNode(ABC):
 
     def setup_datasets(
         self,
-        datasets: Dict[str, dict],
+        datasets: Dict[str, Dataset],
         inputs: Optional[List[str]] = None,
         outputs: Optional[List[str]] = None,
         prefix: Optional[str] = None,
@@ -128,7 +129,10 @@ class AbstractNode(ABC):
                     dataset_name=dataset_name,
                     node_name=self.name,
                     pipeline_name=self.pipeline_name,
-                    dataset_config=datasets.get(dataset_name, {}),
+                    dataset_config=datasets.get(
+                        dataset_name,
+                        Dataset(type="kafka_stream"),
+                    ),
                     prefix=prefix,
                     has_pipeline_prefix=has_pipeline_prefix,
                 )
@@ -143,7 +147,10 @@ class AbstractNode(ABC):
                     dataset_name=dataset_name,
                     node_name=self.name,
                     pipeline_name=self.pipeline_name,
-                    dataset_config=datasets.get(dataset_name, {}),
+                    dataset_config=datasets.get(
+                        dataset_name,
+                        Dataset(type="kafka_stream"),
+                    ),
                     prefix=prefix,
                     has_pipeline_prefix=has_pipeline_prefix,
                 )

--- a/aineko/core/node.py
+++ b/aineko/core/node.py
@@ -131,7 +131,7 @@ class AbstractNode(ABC):
                     pipeline_name=self.pipeline_name,
                     dataset_config=datasets.get(
                         dataset_name,
-                        Dataset(type="kafka_stream"),
+                        Dataset(type=AINEKO_CONFIG.get("KAFKA_STREAM_TYPE")),
                     ),
                     prefix=prefix,
                     has_pipeline_prefix=has_pipeline_prefix,
@@ -149,7 +149,7 @@ class AbstractNode(ABC):
                     pipeline_name=self.pipeline_name,
                     dataset_config=datasets.get(
                         dataset_name,
-                        Dataset(type="kafka_stream"),
+                        Dataset(type=AINEKO_CONFIG.get("KAFKA_STREAM_TYPE")),
                     ),
                     prefix=prefix,
                     has_pipeline_prefix=has_pipeline_prefix,

--- a/aineko/core/runner.py
+++ b/aineko/core/runner.py
@@ -3,7 +3,7 @@
 """Submodule that handles the running of a pipeline from config."""
 import logging
 import time
-from typing import Optional
+from typing import Dict, Optional
 
 import ray
 from confluent_kafka.admin import AdminClient, NewTopic  # type: ignore
@@ -15,6 +15,7 @@ from aineko.config import (
 )
 from aineko.core.config_loader import ConfigLoader
 from aineko.core.node import PoisonPill
+from aineko.models.config_schema import Config, Dataset
 from aineko.utils import imports
 
 logger = logging.getLogger(__name__)
@@ -66,11 +67,11 @@ class Runner:
         """
         # Load pipeline config
         pipeline_config = self.load_pipeline_config()
-        self.pipeline_name = self.pipeline_name or pipeline_config["name"]
+        self.pipeline_name = self.pipeline_name or pipeline_config.name
 
         # Create the necessary datasets
         self.prepare_datasets(
-            config=pipeline_config["datasets"],
+            config=pipeline_config.datasets,
             user_dataset_prefix=self.pipeline_name,
         )
 
@@ -85,9 +86,9 @@ class Runner:
         poison_pill = ray.remote(PoisonPill).remote()
 
         # Add Node Manager to pipeline config
-        pipeline_config["nodes"][
+        pipeline_config.nodes[
             NODE_MANAGER_CONFIG.get("NAME")
-        ] = NODE_MANAGER_CONFIG.get("NODE_CONFIG")
+        ] = Config.Pipeline.Node(**NODE_MANAGER_CONFIG.get("NODE_CONFIG"))
 
         # Create each node (actor)
         results = self.prepare_nodes(
@@ -97,7 +98,7 @@ class Runner:
 
         ray.get(results)
 
-    def load_pipeline_config(self) -> dict:
+    def load_pipeline_config(self) -> Config.Pipeline:
         """Loads the config for a given pipeline.
 
         Returns:
@@ -107,10 +108,12 @@ class Runner:
             pipeline_config_file=self.pipeline_config_file,
         ).load_config()
 
-        return config["pipeline"]
+        return config.pipeline
 
     def prepare_datasets(
-        self, config: dict, user_dataset_prefix: Optional[str] = None
+        self,
+        config: Dict[str, Dataset],
+        user_dataset_prefix: Optional[str] = None,
     ) -> bool:
         """Creates the required datasets for a given pipeline.
 
@@ -155,10 +158,10 @@ class Runner:
                 )
 
         # Add logging dataset to catalog
-        config[DEFAULT_KAFKA_CONFIG.get("LOGGING_DATASET")] = {
-            "type": AINEKO_CONFIG.get("KAFKA_STREAM_TYPE"),
-            "params": DEFAULT_KAFKA_CONFIG.get("DATASET_PARAMS"),
-        }
+        config[DEFAULT_KAFKA_CONFIG.get("LOGGING_DATASET")] = Dataset(
+            type=AINEKO_CONFIG.get("KAFKA_STREAM_TYPE"),
+            params=DEFAULT_KAFKA_CONFIG.get("DATASET_PARAMS"),
+        )
 
         # Create all dataset defined in the catalog
         dataset_list = []
@@ -167,11 +170,14 @@ class Runner:
                 "Creating dataset: %s: %s", dataset_name, dataset_config
             )
             # Create dataset for kafka streams
-            if dataset_config["type"] == AINEKO_CONFIG.get("KAFKA_STREAM_TYPE"):
+            if dataset_config.type == AINEKO_CONFIG.get("KAFKA_STREAM_TYPE"):
                 # User defined
+                if not dataset_config.params:
+                    dataset_config.params = {}
+
                 dataset_params = {
                     **DEFAULT_KAFKA_CONFIG.get("DATASET_PARAMS"),
-                    **dataset_config.get("params", {}),
+                    **dataset_config.params,
                 }
 
                 # Configure dataset
@@ -216,7 +222,9 @@ class Runner:
         return datasets
 
     def prepare_nodes(
-        self, pipeline_config: dict, poison_pill: ray.actor.ActorHandle
+        self,
+        pipeline_config: Config.Pipeline,
+        poison_pill: ray.actor.ActorHandle,
     ) -> list:
         """Prepare actor handles for all nodes.
 
@@ -232,14 +240,20 @@ class Runner:
         """
         # Collect all  actor futures
         results = []
+        if pipeline_config.default_node_settings:
+            default_node_config = pipeline_config.default_node_settings
+        else:
+            default_node_config = {}
 
-        default_node_config = pipeline_config.get("default_node_settings", {})
-
-        for node_name, node_config in pipeline_config["nodes"].items():
+        for node_name, node_config in pipeline_config.nodes.items():
+            if node_config.node_settings:
+                node_settings = node_config.node_settings
+            else:
+                node_settings = {}
             # Initialize actor from specified class in config
             try:
                 target_class = imports.import_from_string(
-                    attr=node_config["class"], kind="class"
+                    attr=node_config.class_name, kind="class"
                 )
             except AttributeError as exc:
                 raise ValueError(
@@ -251,7 +265,7 @@ class Runner:
 
             actor_params = {
                 **default_node_config,
-                **node_config.get("node_settings", {}),
+                **node_settings,
                 "name": node_name,
                 "namespace": self.pipeline_name,
             }
@@ -264,26 +278,33 @@ class Runner:
                 poison_pill=poison_pill,
             )
 
+            if node_config.outputs:
+                outputs = node_config.outputs
+            else:
+                outputs = []
+
+            if node_config.inputs:
+                inputs = node_config.inputs
+            else:
+                inputs = None
             # Setup input and output datasets
-            outputs = node_config.get("outputs", [])
+
             actor_handle.setup_datasets.remote(
-                inputs=node_config.get("inputs", None),
+                inputs=inputs,
                 outputs=outputs,
-                datasets=pipeline_config["datasets"],
+                datasets=pipeline_config.datasets,
                 has_pipeline_prefix=True,
             )
 
             # Setup internal datasets like logging, without pipeline prefix
             actor_handle.setup_datasets.remote(
                 outputs=DEFAULT_KAFKA_CONFIG.get("DATASETS"),
-                datasets=pipeline_config["datasets"],
+                datasets=pipeline_config.datasets,
             )
 
             # Create actor future (for execute method)
             results.append(
-                actor_handle.execute.remote(
-                    params=node_config.get("node_params", None)
-                )
+                actor_handle.execute.remote(params=node_config.node_params)
             )
 
         return results

--- a/aineko/models/config_schema.py
+++ b/aineko/models/config_schema.py
@@ -29,7 +29,7 @@ class Config(BaseModel):
             outputs: Optional[list] = None
 
         name: str
-        default_node_settings: Optional[dict]
+        default_node_settings: Optional[dict] = None
         nodes: Dict[str, Node]
         datasets: Dict[str, Dataset]
 

--- a/aineko/models/config_schema.py
+++ b/aineko/models/config_schema.py
@@ -6,17 +6,18 @@ from typing import Dict, Optional
 from pydantic import BaseModel, Field
 
 
+class Dataset(BaseModel):
+    """Dataset model."""
+
+    type: str
+    params: Optional[dict] = None
+
+
 class Config(BaseModel):
     """Config model."""
 
     class Pipeline(BaseModel):
         """Pipeline model."""
-
-        class Dataset(BaseModel):
-            """Dataset model."""
-
-            type: str
-            params: Optional[dict] = None
 
         class Node(BaseModel):
             """Node model."""

--- a/tests/core/test_config_loader.py
+++ b/tests/core/test_config_loader.py
@@ -70,7 +70,10 @@ def test_load_config(
 
     # Test pipeline config containing single pipeline
     config = ConfigLoader(test_pipeline_config_file).load_config()
-    assert config == EXPECTED_TEST_PIPELINE
+    assert (
+        config.model_dump(exclude_none=True, by_alias=True)
+        == EXPECTED_TEST_PIPELINE
+    )
 
 
 def test_load_invalid_config(test_invalid_pipeline_config_file: str, caplog):


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
With this PR the ConfigLoader will now return the config as a python object instead of only a dict. (we were using the model to validate)
Now all other methods that rely on this dict have also been refactored to handle it correctly.

This PR should be merged after #140 as it relies on those changes.

## Motivation
<!-- Describe the motivation for this change. -->
Allow us to use Pydantic model for better internal DX and a more robust code base.

## Author Checklist

- [ ] Changes are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Documentation is updated if necessary.
- [ ] Status checks pass.
- [ ] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
