### PR TITLE
refactor: config loader to return a python object of the Config instead of a dict

### DIFF
--- a/aineko/core/config_loader.py
+++ b/aineko/core/config_loader.py
@@ -39,32 +39,32 @@ class ConfigLoader:
             "DEFAULT_PIPELINE_CONFIG"
         )
 
-    def load_config(self) -> dict:
+    def load_config(self) -> Config:
         """Load and validate the pipeline config.
 
         Raises:
             ValidationError: If the config does not match the schema
 
         Returns:
-            The pipeline config as a dictionary
+            The validated pipeline config as a Pydantic Config object
         """
-        config = load_yaml(self.pipeline_config_file)
+        raw_config = load_yaml(self.pipeline_config_file)
 
         try:
-            Config(**config)
+            config = Config(**raw_config)
         except ValidationError as e:
             logger.error(
                 "Schema validation failed for pipeline `%s` loaded from %s. "
                 "See detailed error below.",
-                config["pipeline"]["name"],
+                raw_config["pipeline"]["name"],
                 self.pipeline_config_file,
             )
             raise e
 
         # Inject environment variables into node params
-        for node in config["pipeline"]["nodes"].values():
-            if "node_params" in node and node["node_params"] is not None:
-                node["node_params"] = self.inject_env_vars(node["node_params"])
+        for node in config.pipeline.nodes.values():
+            if node.node_params is not None:
+                node.node_params = self.inject_env_vars(node.node_params)
 
         return config
 

--- a/aineko/core/config_loader.py
+++ b/aineko/core/config_loader.py
@@ -24,7 +24,6 @@ class ConfigLoader:
 
     Attributes:
         pipeline_config_file (str): path to the pipeline configuration file
-        config_schema (Config): Pydantic model to validate a pipeline config
 
     Methods:
         load_config: loads and validates the pipeline config from a yaml file
@@ -39,9 +38,6 @@ class ConfigLoader:
         self.pipeline_config_file = pipeline_config_file or AINEKO_CONFIG.get(
             "DEFAULT_PIPELINE_CONFIG"
         )
-
-        # Setup config schema
-        self.config_schema = Config
 
     def load_config(self) -> dict:
         """Load and validate the pipeline config.

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -32,6 +32,7 @@ from confluent_kafka import (  # type: ignore
 )
 
 from aineko.config import AINEKO_CONFIG, DEFAULT_KAFKA_CONFIG
+from aineko.models.config_schema import Config
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +76,7 @@ class DatasetConsumer:
         dataset_name: str,
         node_name: str,
         pipeline_name: str,
-        dataset_config: Dict[str, Any],
+        dataset_config: Union[Dict[str, Any], Config.Pipeline.Dataset],
         bootstrap_servers: Optional[str] = None,
         prefix: Optional[str] = None,
         has_pipeline_prefix: bool = False,
@@ -86,6 +87,9 @@ class DatasetConsumer:
         self.prefix = prefix
         self.has_pipeline_prefix = has_pipeline_prefix
         self.cached = False
+
+        if isinstance(dataset_config, Config.Pipeline.Dataset):
+            dataset_config = dataset_config.model_dump()
 
         consumer_config = self.kafka_config.get("CONSUMER_CONFIG")
         # Overwrite bootstrap server with broker if provided

--- a/aineko/models/config_schema.py
+++ b/aineko/models/config_schema.py
@@ -28,7 +28,7 @@ class Config(BaseModel):
             outputs: Optional[list] = None
 
         name: str
-        default_node_settings: Optional[dict]
+        default_node_settings: Optional[dict] = None
         nodes: Dict[str, Node]
         datasets: Dict[str, Dataset]
 

--- a/tests/core/test_config_loader.py
+++ b/tests/core/test_config_loader.py
@@ -70,7 +70,10 @@ def test_load_config(
 
     # Test pipeline config containing single pipeline
     config = ConfigLoader(test_pipeline_config_file).load_config()
-    assert config == EXPECTED_TEST_PIPELINE
+    assert (
+        config.model_dump(exclude_none=True, by_alias=True)
+        == EXPECTED_TEST_PIPELINE
+    )
 
 
 def test_load_invalid_config(test_invalid_pipeline_config_file: str, caplog):


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
With this PR the ConfigLoader will now return the config as a python object instead of only a dict. (we were using the model to validate)
All other methods that rely on this dict have also been refactored to handle it correctly.


## Motivation
<!-- Describe the motivation for this change. -->
Allow us to use Pydantic model for better internal DX and a more robust code base.

## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
