### PR TITLE
fix: use -1 to block until the next message is available

### DIFF
--- a/aineko/datasets/kafka.py
+++ b/aineko/datasets/kafka.py
@@ -481,7 +481,7 @@ class KafkaDataset(AbstractDataset):
         Returns:
             message from the dataset
         """
-        return self._consume_message(how="next")
+        return self._consume_message(how="next", timeout=-1)
 
     def last(self, timeout: int = 1) -> Dict:
         """Consumes the last message from the dataset.


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
This PR fixes the locking behavior of the KafkaDataset `.next()` method, as reported by @ricrosales on [Slack](https://aineko-dev.slack.com/archives/C05U15ATA2V/p1708036808241439).

Closes #160

## Motivation
<!-- Describe the motivation for this change. -->
Fix unintended behavior.

## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
