### PR TITLE
refactor: AbstractDataset method signatures to be compatible with the AbstractNode

### DIFF
--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -177,8 +177,19 @@ class AbstractDataset(abc.ABC, Generic[T]):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def create(self, *args: T, **kwargs: T) -> DatasetCreationStatus:
-        """Subclass implementation to create the dataset storage layer."""
+    def create(
+        self,
+        dataset_prefix: Optional[str] = None,
+    ) -> DatasetCreationStatus:
+        """Subclass implementation to create the dataset storage layer.
+
+        Args:
+            dataset_prefix: Optional prefix for dataset name.
+
+        Returns:
+            A `DatasetCreationStatus` object representing the creation status
+            of the dataset.
+        """
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/aineko/core/dataset.py
+++ b/aineko/core/dataset.py
@@ -15,7 +15,7 @@ Example dataset configuration:
 """
 import abc
 from concurrent.futures import Future
-from typing import Any, Dict, Generic, List, Optional, TypeVar
+from typing import Any, Dict, Generic, List, Literal, Optional, TypeVar
 
 from aineko.models.dataset_config_schema import DatasetConfig
 from aineko.utils.imports import import_from_string
@@ -198,8 +198,30 @@ class AbstractDataset(abc.ABC, Generic[T]):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def initialize(self, *args: T, **kwargs: T) -> Any:
-        """Subclass implementation to initialize the dataset query layer."""
+    def initialize(
+        self,
+        create: Literal["consumer", "producer"],
+        node_name: str,
+        pipeline_name: str,
+        prefix: Optional[str] = None,
+        has_pipeline_prefix: bool = False,
+    ) -> Any:
+        """Subclass implementation to initialize the dataset query layer.
+
+        The  `initialize` method should initialize a consumer or producer forÒ
+        the dataset, depending on the value of the `create` parameter.
+
+        Args:
+            create: whether to create a consumer or producer for the dataset
+            node_name: name of the node
+            pipeline_name: name of the pipeline that the node belongs to
+            prefix: prefix for the dataset topic
+            has_pipeline_prefix: Whether the dataset topic has a pipeline prefix
+
+        Raises:
+            DatasetError: If an error occurs while creating the consumer or
+                producer.
+        """
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/aineko/datasets/kafka.py
+++ b/aineko/datasets/kafka.py
@@ -174,7 +174,8 @@ class KafkaDataset(AbstractDataset):
             dataset_prefix: Optional prefix for dataset name.
 
         Returns:
-          status of dataset creation.
+            A `DatasetCreationStatus` object representing the creation status
+            of the dataset.
         """
         return self._create_topic(
             dataset_name=self.name, dataset_prefix=dataset_prefix


### PR DESCRIPTION
## Summary
<!-- Describe the changes in this PR. -->
This PR modifies the signature of the AbstractDataset methods `create` and `initialize` to be compatible with the AbstractNode.

## Motivation
<!-- Describe the motivation for this change. -->
This is necessary so the node implementation remains compatible with all current and future dataset plugins.

## Author Checklist

- [x] Changes are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Documentation is updated if necessary.
- [x] Status checks pass.
- [x] If the version number is changed, it is updated in `pyproject.toml` , `aineko/__init__.py`, `aineko/templates/first_aineko_pipeline/{{cookiecutter.project_slug}}/pyproject.toml`.


## Reviewer Checklist

- [ ] Title is accurate and formatted appropriately.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Docs are updated if necessary.
- [ ] Code is pythonic and consistent with the rest of the codebase.
- [ ] The code is consistent with the [style guide](https://google.github.io/styleguide/pyguide.html).
